### PR TITLE
Apply single responsibility principle to all tests

### DIFF
--- a/tests/base.cpp
+++ b/tests/base.cpp
@@ -176,25 +176,19 @@ SCENARIO("Testing gst::ranges::zip_view member functions", "zip_view")
     {
       auto gst_front = gst_zipped.front();
       auto std_front = std_zipped.front();
-      REQUIRE(std::get<0>(gst_front) == std::get<0>(std_front));
-      REQUIRE(std::get<1>(gst_front) == std::get<1>(std_front));
-      REQUIRE(std::equal_to{}(std::get<2>(gst_front), std::get<2>(std_front)));
+      REQUIRE((gst_front == std_front));
     }
 
     THEN("The back element shall be the last elements of each container")
     {
       auto gst_back = gst_zipped.back();
-      REQUIRE(std::get<0>(gst_back) == 3);
-      REQUIRE(std::get<1>(gst_back) == 'c');
-      REQUIRE(std::equal_to{}(std::get<2>(gst_back), 3.3F));
+      REQUIRE((gst_back == std::make_tuple(3, 'c', 3.3F)));
     }
 
     THEN("The subscript operator shall return the correct elements")
     {
       auto gst_elem = gst_zipped[1];
-      REQUIRE(std::get<0>(gst_elem) == 2);
-      REQUIRE(std::get<1>(gst_elem) == 'b');
-      REQUIRE(std::equal_to{}(std::get<2>(gst_elem), 2.2F));
+      REQUIRE((gst_elem == std::make_tuple(2, 'b', 2.2F)));
     }
 
     THEN("The conversion operator shall return true")
@@ -223,25 +217,19 @@ SCENARIO("Testing gst::ranges::zip_view member functions", "zip_view")
     {
       auto gst_front = gst_zipped.front();
       auto std_front = std_zipped.front();
-      REQUIRE(std::get<0>(gst_front) == std::get<0>(std_front));
-      REQUIRE(std::get<1>(gst_front) == std::get<1>(std_front));
-      REQUIRE(std::equal_to{}(std::get<2>(gst_front), std::get<2>(std_front)));
+      REQUIRE((gst_front == std_front));
     }
 
     THEN("The back element shall be the last elements of each container up to the smallest size")
     {
       auto gst_back = gst_zipped.back();
-      REQUIRE(std::get<0>(gst_back) == 2);
-      REQUIRE(std::get<1>(gst_back) == 'b');
-      REQUIRE(std::equal_to{}(std::get<2>(gst_back), 2.2F));
+      REQUIRE((gst_back == std::make_tuple(2, 'b', 2.2F)));
     }
 
     THEN("The subscript operator shall return the correct elements")
     {
       auto gst_elem = gst_zipped[1];
-      REQUIRE(std::get<0>(gst_elem) == 2);
-      REQUIRE(std::get<1>(gst_elem) == 'b');
-      REQUIRE(std::equal_to{}(std::get<2>(gst_elem), 2.2F));
+      REQUIRE((gst_elem == std::make_tuple(2, 'b', 2.2F)));
     }
 
     THEN("The conversion operator shall return correct boolean value")
@@ -265,19 +253,24 @@ SCENARIO("Testing gst::ranges::zip_view member functions", "zip_view")
       auto             gst_zipped = gst::ranges::views::zip(vec);
       auto             std_zipped = std::ranges::views::zip(vec);
       auto             elem       = gst_zipped[2];
-      REQUIRE(std::get<0>(elem) == 3);
       REQUIRE(std::get<0>(elem) == std::get<0>(std_zipped[2]));
     }
 
-    THEN("front() and back() work correctly")
+    THEN("front() returns correct element")
     {
       std::vector<int> vec        = {1, 2, 3, 4, 5};
       auto             gst_zipped = gst::ranges::views::zip(vec);
       REQUIRE(std::get<0>(gst_zipped.front()) == 1);
+    }
+
+    THEN("back() returns correct element")
+    {
+      std::vector<int> vec        = {1, 2, 3, 4, 5};
+      auto             gst_zipped = gst::ranges::views::zip(vec);
       REQUIRE(std::get<0>(gst_zipped.back()) == 5);
     }
 
-    THEN("Can iterate and modify through single container zip")
+    THEN("Can iterate and modify elements")
     {
       std::vector<int> vec        = {1, 2, 3, 4, 5};
       auto             gst_zipped = gst::ranges::views::zip(vec);

--- a/tests/edge.cpp
+++ b/tests/edge.cpp
@@ -56,9 +56,7 @@ SCENARIO("Testing gst::ranges::zip_view with edge scenarios", "[edge]")
     {
       auto gst_front = gst_zipped.front();
       auto std_front = std_zipped.front();
-      REQUIRE(std::get<0>(gst_front) == std::get<0>(std_front));
-      REQUIRE(std::get<1>(gst_front) == std::get<1>(std_front));
-      REQUIRE(std::equal_to{}(std::get<2>(gst_front), std::get<2>(std_front)));
+      REQUIRE((gst_front == std_front));
     }
   }
 
@@ -80,9 +78,7 @@ SCENARIO("Testing gst::ranges::zip_view with edge scenarios", "[edge]")
     THEN("The elements should match the corresponding elements of each container")
     {
       auto gst_elem = gst_zipped[1];
-      REQUIRE(std::get<0>(gst_elem) == 2);
-      REQUIRE(std::get<1>(gst_elem) == "b");
-      REQUIRE(std::equal_to{}(std::get<2>(gst_elem), 2.2));
+      REQUIRE((gst_elem == std::make_tuple(2, "b", 2.2)));
     }
   }
 
@@ -139,9 +135,8 @@ SCENARIO("Testing gst::ranges::zip_view with edge scenarios", "[edge]")
     THEN("The elements should match the corresponding elements of each container")
     {
       auto gst_elem = gst_zipped[1];
-      REQUIRE(std::get<0>(gst_elem) == Custom{2, 'b', 2.2F});
-      REQUIRE(std::get<1>(gst_elem) == Custom{4, 'd', 4.4F});
-      REQUIRE(std::get<2>(gst_elem) == Custom{6, 'f', 6.6F});
+      REQUIRE((gst_elem ==
+               std::make_tuple(Custom{2, 'b', 2.2F}, Custom{4, 'd', 4.4F}, Custom{6, 'f', 6.6F})));
     }
   }
 
@@ -198,23 +193,17 @@ SCENARIO("Testing gst::ranges::zip_view with constant containers", "[edge]")
       THEN("The front element should be the first elements of each container")
       {
         auto const gst_front = gst_zipped.front();
-        REQUIRE(std::get<0>(gst_front) == 1);
-        REQUIRE(std::get<1>(gst_front) == 'a');
-        REQUIRE(std::equal_to{}(std::get<2>(gst_front), 1.1F));
+        REQUIRE((gst_front == std::make_tuple(1, 'a', 1.1F)));
       }
       THEN("The back element should be the last elements of each container")
       {
         auto const gst_back = gst_zipped.back();
-        REQUIRE(std::get<0>(gst_back) == 3);
-        REQUIRE(std::get<1>(gst_back) == 'c');
-        REQUIRE(std::equal_to{}(std::get<2>(gst_back), 3.3F));
+        REQUIRE((gst_back == std::make_tuple(3, 'c', 3.3F)));
       }
       THEN("The subscript operator should return the correct elements")
       {
         auto const gst_elem = gst_zipped[1];
-        REQUIRE(std::get<0>(gst_elem) == 2);
-        REQUIRE(std::get<1>(gst_elem) == 'b');
-        REQUIRE(std::equal_to{}(std::get<2>(gst_elem), 2.2F));
+        REQUIRE((gst_elem == std::make_tuple(2, 'b', 2.2F)));
       }
       THEN("The zip_view should be convertible to bool")
       {
@@ -231,23 +220,17 @@ SCENARIO("Testing gst::ranges::zip_view with constant containers", "[edge]")
       THEN("The front element should be the first elements of each container")
       {
         auto const gst_front = gst_zipped.front();
-        REQUIRE(std::get<0>(gst_front) == 1);
-        REQUIRE(std::get<1>(gst_front) == 'a');
-        REQUIRE(std::equal_to{}(std::get<2>(gst_front), 1.1F));
+        REQUIRE((gst_front == std::make_tuple(1, 'a', 1.1F)));
       }
       THEN("The back element should be the last elements of each container")
       {
         auto const gst_back = gst_zipped.back();
-        REQUIRE(std::get<0>(gst_back) == 3);
-        REQUIRE(std::get<1>(gst_back) == 'c');
-        REQUIRE(std::equal_to{}(std::get<2>(gst_back), 3.3F));
+        REQUIRE((gst_back == std::make_tuple(3, 'c', 3.3F)));
       }
       THEN("The subscript operator should return the correct elements")
       {
         auto const gst_elem = gst_zipped[1];
-        REQUIRE(std::get<0>(gst_elem) == 2);
-        REQUIRE(std::get<1>(gst_elem) == 'b');
-        REQUIRE(std::equal_to{}(std::get<2>(gst_elem), 2.2F));
+        REQUIRE((gst_elem == std::make_tuple(2, 'b', 2.2F)));
       }
       THEN("The zip_view should be convertible to bool")
       {
@@ -271,23 +254,17 @@ SCENARIO("Testing gst::ranges::zip_view with constant containers", "[edge]")
       THEN("The front element should be the first elements of each container")
       {
         auto const gst_front = gst_zipped.front();
-        REQUIRE(std::get<0>(gst_front) == 1);
-        REQUIRE(std::get<1>(gst_front) == 'a');
-        REQUIRE(std::equal_to{}(std::get<2>(gst_front), 1.1F));
+        REQUIRE((gst_front == std::make_tuple(1, 'a', 1.1F)));
       }
       THEN("The back element should be the last elements of each container")
       {
         auto const gst_back = gst_zipped.back();
-        REQUIRE(std::get<0>(gst_back) == 3);
-        REQUIRE(std::get<1>(gst_back) == 'c');
-        REQUIRE(std::equal_to{}(std::get<2>(gst_back), 3.3F));
+        REQUIRE((gst_back == std::make_tuple(3, 'c', 3.3F)));
       }
       THEN("The subscript operator should return the correct elements")
       {
         auto const gst_elem = gst_zipped[1];
-        REQUIRE(std::get<0>(gst_elem) == 2);
-        REQUIRE(std::get<1>(gst_elem) == 'b');
-        REQUIRE(std::equal_to{}(std::get<2>(gst_elem), 2.2F));
+        REQUIRE((gst_elem == std::make_tuple(2, 'b', 2.2F)));
       }
       THEN("The zip_view should be convertible to bool")
       {
@@ -351,11 +328,9 @@ SCENARIO("Testing subscript operator read and write", "[edge]")
         zip[1] = std::make_tuple(20, 50.2);
         zip[2] = std::make_tuple(30, 60.3);
 
-        AND_THEN("the elements of the original containers are updated")
-        {
-          REQUIRE(v1 == std::array<int, 3>{10, 20, 30});
-          REQUIRE(v2 == std::list<double>{40.1, 50.2, 60.3});
-        }
+        REQUIRE(v1 == std::array<int, 3>{10, 20, 30});
+        REQUIRE(v2 == std::list<double>{40.1, 50.2, 60.3});
+        REQUIRE((zip[1] == std::make_tuple(20, 50.2)));
       }
     }
 
@@ -371,11 +346,9 @@ SCENARIO("Testing subscript operator read and write", "[edge]")
         zip[1] = std::make_tuple(20, 50.2);
         zip[2] = std::make_tuple(30, 60.3);
 
-        AND_THEN("the elements of the original containers are updated")
-        {
-          REQUIRE(v1 == std::array<int, 3>{10, 20, 30});
-          REQUIRE(v2 == std::list<double>{40.1, 50.2, 60.3});
-        }
+        REQUIRE(v1 == std::array<int, 3>{10, 20, 30});
+        REQUIRE(v2 == std::list<double>{40.1, 50.2, 60.3});
+        REQUIRE((zip[2] == std::make_tuple(30, 60.3)));
       }
     }
   }
@@ -398,9 +371,7 @@ SCENARIO("Testing gst::ranges::zip_view with modified containers", "[edge]")
       deq.push_back(4.4F);
 
       REQUIRE(gst_zipped.size() == 4);
-      REQUIRE(std::get<0>(gst_zipped[3]) == 4);
-      REQUIRE(std::get<1>(gst_zipped[3]) == 'd');
-      REQUIRE(std::equal_to{}(std::get<2>(gst_zipped[3]), 4.4F));
+      REQUIRE((gst_zipped[3] == std::make_tuple(4, 'd', 4.4F)));
     }
   }
 }
@@ -428,25 +399,19 @@ SCENARIO("Testing const and non-const access to zip_view", "[const_correctness]"
       THEN("non-const front() works")
       {
         auto front_elem = zipped.front();
-        REQUIRE(std::get<0>(front_elem) == 1);
-        REQUIRE(std::get<1>(front_elem) == 'a');
-        REQUIRE(std::equal_to{}(std::get<2>(front_elem), 1.1F));
+        REQUIRE((front_elem == std::make_tuple(1, 'a', 1.1F)));
       }
 
       THEN("non-const back() works")
       {
         auto back_elem = zipped.back();
-        REQUIRE(std::get<0>(back_elem) == 5);
-        REQUIRE(std::get<1>(back_elem) == 'e');
-        REQUIRE(std::equal_to{}(std::get<2>(back_elem), 5.5F));
+        REQUIRE((back_elem == std::make_tuple(5, 'e', 5.5F)));
       }
 
       THEN("non-const operator[] works")
       {
         auto elem = zipped[2];
-        REQUIRE(std::get<0>(elem) == 3);
-        REQUIRE(std::get<1>(elem) == 'c');
-        REQUIRE(std::equal_to{}(std::get<2>(elem), 3.3F));
+        REQUIRE((elem == std::make_tuple(3, 'c', 3.3F)));
       }
     }
 
@@ -473,25 +438,19 @@ SCENARIO("Testing const and non-const access to zip_view", "[const_correctness]"
       THEN("const front() works")
       {
         auto front_elem = zipped.front();
-        REQUIRE(std::get<0>(front_elem) == 1);
-        REQUIRE(std::get<1>(front_elem) == 'a');
-        REQUIRE(std::equal_to{}(std::get<2>(front_elem), 1.1F));
+        REQUIRE((front_elem == std::make_tuple(1, 'a', 1.1F)));
       }
 
       THEN("const back() works")
       {
         auto back_elem = zipped.back();
-        REQUIRE(std::get<0>(back_elem) == 5);
-        REQUIRE(std::get<1>(back_elem) == 'e');
-        REQUIRE(std::equal_to{}(std::get<2>(back_elem), 5.5F));
+        REQUIRE((back_elem == std::make_tuple(5, 'e', 5.5F)));
       }
 
       THEN("const operator[] works")
       {
         auto elem = zipped[2];
-        REQUIRE(std::get<0>(elem) == 3);
-        REQUIRE(std::get<1>(elem) == 'c');
-        REQUIRE(std::equal_to{}(std::get<2>(elem), 3.3F));
+        REQUIRE((elem == std::make_tuple(3, 'c', 3.3F)));
       }
 
       THEN("const operator bool() works correctly") { REQUIRE(static_cast<bool>(zipped) == true); }

--- a/tests/iter.cpp
+++ b/tests/iter.cpp
@@ -179,11 +179,7 @@ SCENARIO("zip_view random access iterator operations", "[random_access]")
       REQUIRE(std::get<1>(*it2) == Catch::Approx(40.0));
     }
 
-    THEN("we can calculate distance with operator- between iterators")
-    {
-      REQUIRE(end - it == 5);
-      REQUIRE((it + 3) - it == 3);
-    }
+    THEN("we can calculate distance with operator- between iterators") { REQUIRE(end - it == 5); }
 
     THEN("we can use operator[]")
     {
@@ -206,14 +202,29 @@ SCENARIO("zip_view random access iterator operations", "[random_access]")
       REQUIRE(std::get<0>(*it2) == 4);
     }
 
-    THEN("we can use relational operators")
+    THEN("we can use relational operators <")
     {
       auto it2 = it + 2;
       REQUIRE(it < it2);
+    }
+
+    THEN("we can use relational operators >")
+    {
+      auto it2 = it + 2;
       REQUIRE(it2 > it);
+    }
+
+    THEN("we can use relational operators <=")
+    {
+      auto it2 = it + 2;
       REQUIRE(it <= it2);
-      REQUIRE(it2 >= it);
       REQUIRE(it <= it);
+    }
+
+    THEN("we can use relational operators >=")
+    {
+      auto it2 = it + 2;
+      REQUIRE(it2 >= it);
       REQUIRE(it >= it);
     }
   }
@@ -413,12 +424,11 @@ SCENARIO("Testing iterator copy and move semantics", "[iterator]")
 
       THEN("Both iterators point to the same element")
       {
-        REQUIRE(std::get<0>(*it1) == std::get<0>(*it2));
-        REQUIRE(std::get<1>(*it1) == std::get<1>(*it2));
+        REQUIRE((*it1 == *it2));
         REQUIRE(it1 == it2);
       }
 
-      THEN("Modifying one doesn't affect the other's position")
+      THEN("Modifying one iterator doesn't affect the other's position")
       {
         ++it1;
         REQUIRE(it1 != it2);
@@ -455,11 +465,7 @@ SCENARIO("Testing iterator copy and move semantics", "[iterator]")
       auto it2 = zipped.begin();
       it2      = std::move(it1); // Move assign
 
-      THEN("Moved-to iterator points to original position")
-      {
-        REQUIRE(std::get<0>(*it2) == 5);
-        REQUIRE(std::get<1>(*it2) == 'e');
-      }
+      THEN("Moved-to iterator points to original position") { REQUIRE(std::get<0>(*it2) == 5); }
     }
   }
 }
@@ -544,11 +550,7 @@ SCENARIO("Testing iterator edge cases with arithmetic", "[iterator]")
       auto it  = zipped.end();
       it      -= 1;
 
-      THEN("Can access last element")
-      {
-        REQUIRE(std::get<0>(*it) == 50);
-        REQUIRE(std::get<1>(*it) == 5);
-      }
+      THEN("Can access last element") { REQUIRE(std::get<0>(*it) == 50); }
     }
   }
 }


### PR DESCRIPTION
Refactored test suite to ensure each test verifies exactly one specific
behavior, improving clarity, maintainability, and debugging efficiency.

Major Changes:
- Flattened nested THEN/AND_THEN structures: removed all nested test blocks
  to maintain consistent single-level structure (GIVEN/WHEN/THEN only)
- Simplified tuple assertions: replaced multiple std::get<N>() checks with
  single tuple comparisons (e.g., elem == std::make_tuple(x, y, z))
  Note: Tuple equality operator checks all elements, so this maintains
  complete verification while reducing assertion count.
- Split combined function tests: separated tests that verified multiple
  member functions (front/back, read/write) into focused individual tests
- Simplified complex predicates: reduced algorithm tests to test the
  algorithm itself, not complex logic within predicates
- Removed redundant container checks: verify one representative container
  instead of checking all 3 containers for the same behavior
  Rationale: Tests focus on zip_view's iterator interface, not on verifying
  standard library algorithms work with each container type. If zip_view's
  iterator correctly forwards operations, behavior is identical across all
  underlying container types.
- Split iterator operation tests: separated relational operators and
  arithmetic operations into individual test cases
- Preserved view semantics validation: kept checks that verify zip_view
  properly reflects modifications to underlying containers (e.g., after
  modifying elements, verify both the container AND that the zip_view
  still reflects those changes). This validates the critical property
  that zip_view remains a proper view after modifications.