### PR TITLE
Fix nested zip views

### DIFF
--- a/benchmarks/nest.cpp
+++ b/benchmarks/nest.cpp
@@ -237,13 +237,13 @@ TEST_CASE("Benchmark Nested ZipView Deep Nesting", "[nested]")
   std::iota(v7.begin(), v7.end(), 300000);
   std::iota(v8.begin(), v8.end(), 350000);
 
-  auto zip1_1     = gst::ranges::views::zip(v1, v2);
-  auto zip1_2     = gst::ranges::views::zip(v3, v4);
-  auto zip2_1     = gst::ranges::views::zip(v5, v6);
-  auto zip2_2     = gst::ranges::views::zip(v7, v8);
-  auto nested_1   = gst::ranges::views::zip(zip1_1, zip1_2);
-  auto nested_2   = gst::ranges::views::zip(zip2_1, zip2_2);
-  auto deep_neste = gst::ranges::views::zip(nested_1, nested_2);
+  auto zip1_1      = gst::ranges::views::zip(v1, v2);
+  auto zip1_2      = gst::ranges::views::zip(v3, v4);
+  auto zip2_1      = gst::ranges::views::zip(v5, v6);
+  auto zip2_2      = gst::ranges::views::zip(v7, v8);
+  auto nested_1    = gst::ranges::views::zip(zip1_1, zip1_2);
+  auto nested_2    = gst::ranges::views::zip(zip2_1, zip2_2);
+  auto deep_nested = gst::ranges::views::zip(nested_1, nested_2);
 
   BENCHMARK("flat zip iterate (8 ranges)")
   {
@@ -276,7 +276,7 @@ TEST_CASE("Benchmark Nested ZipView Deep Nesting", "[nested]")
   BENCHMARK("deep nested zip iterate (2x(2x2) ranges)")
   {
     int sum = 0;
-    for (auto t : deep_neste)
+    for (auto t : deep_nested)
     {
       auto n0   = std::get<0>(t);
       auto n1   = std::get<1>(t);

--- a/benchmarks/nest.cpp
+++ b/benchmarks/nest.cpp
@@ -1,0 +1,334 @@
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+#endif
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <catch2/catch_test_macros.hpp>
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+#include "zip_view.hpp"
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+TEST_CASE("Benchmark Nested ZipView Iteration", "[nested]")
+{
+  std::vector<int> v1(100000);
+  std::vector<int> v2(100000);
+  std::vector<int> v3(100000);
+  std::vector<int> v4(100000);
+
+  std::iota(v1.begin(), v1.end(), 0);
+  std::iota(v2.begin(), v2.end(), 100000);
+  std::iota(v3.begin(), v3.end(), 200000);
+  std::iota(v4.begin(), v4.end(), 300000);
+
+  auto zip1   = gst::ranges::views::zip(v1, v2);
+  auto zip2   = gst::ranges::views::zip(v3, v4);
+  auto nested = gst::ranges::views::zip(zip1, zip2);
+
+  BENCHMARK("flat zip iterate (4 ranges)")
+  {
+    auto flat_zip = gst::ranges::views::zip(v1, v2, v3, v4);
+    int  sum      = 0;
+    for (auto t : flat_zip)
+    {
+      sum += std::get<0>(t) + std::get<1>(t) + std::get<2>(t) + std::get<3>(t);
+    }
+    return sum;
+  };
+
+  BENCHMARK("nested zip iterate (2x2 ranges)")
+  {
+    int sum = 0;
+    for (auto t : nested)
+    {
+      auto t0  = std::get<0>(t);
+      auto t1  = std::get<1>(t);
+      sum     += std::get<0>(t0) + std::get<1>(t0) + std::get<0>(t1) + std::get<1>(t1);
+    }
+    return sum;
+  };
+}
+
+TEST_CASE("Benchmark Nested ZipView Accumulate", "[nested]")
+{
+  std::vector<int> v1(100000);
+  std::vector<int> v2(100000);
+  std::vector<int> v3(100000);
+  std::vector<int> v4(100000);
+
+  std::iota(v1.begin(), v1.end(), 0);
+  std::iota(v2.begin(), v2.end(), 100000);
+  std::iota(v3.begin(), v3.end(), 200000);
+  std::iota(v4.begin(), v4.end(), 300000);
+
+  auto zip1   = gst::ranges::views::zip(v1, v2);
+  auto zip2   = gst::ranges::views::zip(v3, v4);
+  auto nested = gst::ranges::views::zip(zip1, zip2);
+
+  BENCHMARK("flat zip accumulate")
+  {
+    auto flat_zip = gst::ranges::views::zip(v1, v2, v3, v4);
+    return std::accumulate(
+      flat_zip.begin(),
+      flat_zip.end(),
+      0,
+      [](auto acc, auto t)
+      { return acc + std::get<0>(t) + std::get<1>(t) + std::get<2>(t) + std::get<3>(t); });
+  };
+
+  BENCHMARK("nested zip accumulate")
+  {
+    return std::accumulate(nested.begin(),
+                           nested.end(),
+                           0,
+                           [](auto acc, auto t)
+                           {
+                             auto t0 = std::get<0>(t);
+                             auto t1 = std::get<1>(t);
+                             return acc + std::get<0>(t0) + std::get<1>(t0) + std::get<0>(t1) +
+                                    std::get<1>(t1);
+                           });
+  };
+}
+
+TEST_CASE("Benchmark Nested ZipView Transform", "[nested]")
+{
+  std::vector<int> v1(100000);
+  std::vector<int> v2(100000);
+  std::vector<int> v3(100000);
+  std::vector<int> v4(100000);
+  std::vector<int> out(100000);
+
+  std::iota(v1.begin(), v1.end(), 0);
+  std::iota(v2.begin(), v2.end(), 100000);
+  std::iota(v3.begin(), v3.end(), 200000);
+  std::iota(v4.begin(), v4.end(), 300000);
+
+  auto zip1   = gst::ranges::views::zip(v1, v2);
+  auto zip2   = gst::ranges::views::zip(v3, v4);
+  auto nested = gst::ranges::views::zip(zip1, zip2);
+
+  BENCHMARK("flat zip transform")
+  {
+    auto flat_zip = gst::ranges::views::zip(v1, v2, v3, v4);
+    std::transform(flat_zip.begin(),
+                   flat_zip.end(),
+                   out.begin(),
+                   [](auto t)
+                   { return std::get<0>(t) + std::get<1>(t) + std::get<2>(t) + std::get<3>(t); });
+    return out;
+  };
+
+  BENCHMARK("nested zip transform")
+  {
+    std::transform(nested.begin(),
+                   nested.end(),
+                   out.begin(),
+                   [](auto t)
+                   {
+                     auto t0 = std::get<0>(t);
+                     auto t1 = std::get<1>(t);
+                     return std::get<0>(t0) + std::get<1>(t0) + std::get<0>(t1) + std::get<1>(t1);
+                   });
+    return out;
+  };
+}
+
+TEST_CASE("Benchmark Nested ZipView Find", "[nested]")
+{
+  std::vector<int> v1(100000);
+  std::vector<int> v2(100000);
+  std::vector<int> v3(100000);
+  std::vector<int> v4(100000);
+
+  std::iota(v1.begin(), v1.end(), 0);
+  std::iota(v2.begin(), v2.end(), 100000);
+  std::iota(v3.begin(), v3.end(), 200000);
+  std::iota(v4.begin(), v4.end(), 300000);
+
+  auto zip1   = gst::ranges::views::zip(v1, v2);
+  auto zip2   = gst::ranges::views::zip(v3, v4);
+  auto nested = gst::ranges::views::zip(zip1, zip2);
+
+  BENCHMARK("flat zip find_if")
+  {
+    auto flat_zip = gst::ranges::views::zip(v1, v2, v3, v4);
+    auto it       = std::find_if(
+      flat_zip.begin(), flat_zip.end(), [](auto const& t) { return std::get<0>(t) == 75000; });
+    return it != flat_zip.end();
+  };
+
+  BENCHMARK("nested zip find_if")
+  {
+    auto it = std::find_if(nested.begin(),
+                           nested.end(),
+                           [](auto const& t)
+                           {
+                             auto t0 = std::get<0>(t);
+                             return std::get<0>(t0) == 75000;
+                           });
+    return it != nested.end();
+  };
+}
+
+TEST_CASE("Benchmark Nested ZipView For_each", "[nested]")
+{
+  std::vector<int> v1(100000);
+  std::vector<int> v2(100000);
+  std::vector<int> v3(100000);
+  std::vector<int> v4(100000);
+
+  std::iota(v1.begin(), v1.end(), 0);
+  std::iota(v2.begin(), v2.end(), 100000);
+  std::iota(v3.begin(), v3.end(), 200000);
+  std::iota(v4.begin(), v4.end(), 300000);
+
+  auto zip1   = gst::ranges::views::zip(v1, v2);
+  auto zip2   = gst::ranges::views::zip(v3, v4);
+  auto nested = gst::ranges::views::zip(zip1, zip2);
+
+  BENCHMARK("flat zip for_each")
+  {
+    auto flat_zip = gst::ranges::views::zip(v1, v2, v3, v4);
+    int  sum      = 0;
+    std::for_each(flat_zip.begin(),
+                  flat_zip.end(),
+                  [&sum](auto t)
+                  { sum += std::get<0>(t) + std::get<1>(t) + std::get<2>(t) + std::get<3>(t); });
+    return sum;
+  };
+
+  BENCHMARK("nested zip for_each")
+  {
+    int sum = 0;
+    std::for_each(nested.begin(),
+                  nested.end(),
+                  [&sum](auto t)
+                  {
+                    auto t0 = std::get<0>(t);
+                    auto t1 = std::get<1>(t);
+                    sum += std::get<0>(t0) + std::get<1>(t0) + std::get<0>(t1) + std::get<1>(t1);
+                  });
+    return sum;
+  };
+}
+
+TEST_CASE("Benchmark Nested ZipView Deep Nesting", "[nested]")
+{
+  std::vector<int> v1(50000);
+  std::vector<int> v2(50000);
+  std::vector<int> v3(50000);
+  std::vector<int> v4(50000);
+  std::vector<int> v5(50000);
+  std::vector<int> v6(50000);
+  std::vector<int> v7(50000);
+  std::vector<int> v8(50000);
+
+  std::iota(v1.begin(), v1.end(), 0);
+  std::iota(v2.begin(), v2.end(), 50000);
+  std::iota(v3.begin(), v3.end(), 100000);
+  std::iota(v4.begin(), v4.end(), 150000);
+  std::iota(v5.begin(), v5.end(), 200000);
+  std::iota(v6.begin(), v6.end(), 250000);
+  std::iota(v7.begin(), v7.end(), 300000);
+  std::iota(v8.begin(), v8.end(), 350000);
+
+  auto zip1_1     = gst::ranges::views::zip(v1, v2);
+  auto zip1_2     = gst::ranges::views::zip(v3, v4);
+  auto zip2_1     = gst::ranges::views::zip(v5, v6);
+  auto zip2_2     = gst::ranges::views::zip(v7, v8);
+  auto nested_1   = gst::ranges::views::zip(zip1_1, zip1_2);
+  auto nested_2   = gst::ranges::views::zip(zip2_1, zip2_2);
+  auto deep_neste = gst::ranges::views::zip(nested_1, nested_2);
+
+  BENCHMARK("flat zip iterate (8 ranges)")
+  {
+    auto flat_zip = gst::ranges::views::zip(v1, v2, v3, v4, v5, v6, v7, v8);
+    int  sum      = 0;
+    for (auto t : flat_zip)
+    {
+      sum += std::get<0>(t) + std::get<1>(t) + std::get<2>(t) + std::get<3>(t) + std::get<4>(t) +
+             std::get<5>(t) + std::get<6>(t) + std::get<7>(t);
+    }
+    return sum;
+  };
+
+  BENCHMARK("nested zip iterate (2x2 ranges)")
+  {
+    auto nested = gst::ranges::views::zip(zip1_1, zip1_2, zip2_1, zip2_2);
+    int  sum    = 0;
+    for (auto t : nested)
+    {
+      auto t0  = std::get<0>(t);
+      auto t1  = std::get<1>(t);
+      auto t2  = std::get<2>(t);
+      auto t3  = std::get<3>(t);
+      sum     += std::get<0>(t0) + std::get<1>(t0) + std::get<0>(t1) + std::get<1>(t1) +
+             std::get<0>(t2) + std::get<1>(t2) + std::get<0>(t3) + std::get<1>(t3);
+    }
+    return sum;
+  };
+
+  BENCHMARK("deep nested zip iterate (2x(2x2) ranges)")
+  {
+    int sum = 0;
+    for (auto t : deep_neste)
+    {
+      auto n0   = std::get<0>(t);
+      auto n1   = std::get<1>(t);
+      auto t00  = std::get<0>(n0);
+      auto t01  = std::get<1>(n0);
+      auto t10  = std::get<0>(n1);
+      auto t11  = std::get<1>(n1);
+      sum      += std::get<0>(t00) + std::get<1>(t00) + std::get<0>(t01) + std::get<1>(t01) +
+             std::get<0>(t10) + std::get<1>(t10) + std::get<0>(t11) + std::get<1>(t11);
+    }
+    return sum;
+  };
+}
+
+TEST_CASE("Benchmark Nested ZipView Subscript Access", "[nested]")
+{
+  std::vector<int> v1(100000);
+  std::vector<int> v2(100000);
+  std::vector<int> v3(100000);
+  std::vector<int> v4(100000);
+
+  std::iota(v1.begin(), v1.end(), 0);
+  std::iota(v2.begin(), v2.end(), 100000);
+  std::iota(v3.begin(), v3.end(), 200000);
+  std::iota(v4.begin(), v4.end(), 300000);
+
+  auto zip1   = gst::ranges::views::zip(v1, v2);
+  auto zip2   = gst::ranges::views::zip(v3, v4);
+  auto nested = gst::ranges::views::zip(zip1, zip2);
+
+  BENCHMARK("flat zip subscript access")
+  {
+    auto flat_zip = gst::ranges::views::zip(v1, v2, v3, v4);
+    int  sum      = 0;
+    for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(flat_zip.size()); ++i)
+    {
+      auto t  = flat_zip[i];
+      sum    += std::get<0>(t) + std::get<1>(t) + std::get<2>(t) + std::get<3>(t);
+    }
+    return sum;
+  };
+
+  BENCHMARK("nested zip subscript access")
+  {
+    int sum = 0;
+    for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(nested.size()); ++i)
+    {
+      auto t   = nested[i];
+      auto t0  = std::get<0>(t);
+      auto t1  = std::get<1>(t);
+      sum     += std::get<0>(t0) + std::get<1>(t0) + std::get<0>(t1) + std::get<1>(t1);
+    }
+    return sum;
+  };
+}

--- a/include/zip_view.hpp
+++ b/include/zip_view.hpp
@@ -434,14 +434,12 @@ public:
       return !(*this < other);
     }
 
-    // Friend function for n + iterator
     template <bool B = is_random_access, typename std::enable_if<B, int>::type = 0>
     friend auto operator+(difference_type const n, basic_iterator const& it) -> basic_iterator
     {
       return it + n;
     }
 
-    // Custom iter_swap for proper swapping of zipped elements
     friend auto iter_swap(basic_iterator const& lhs, basic_iterator const& rhs) -> void
     {
       iter_swap_impl(lhs, rhs, INDICES);

--- a/include/zip_view.hpp
+++ b/include/zip_view.hpp
@@ -251,14 +251,14 @@ private:
   template <std::size_t... Is>
   auto subscripts(std::ptrdiff_t const index, detail::index_sequence<Is...>) -> references
   {
-    return std::tie(*std::next(std::get<Is>(views_).begin(), index)...);
+    return references(*std::next(std::get<Is>(views_).begin(), index)...);
   }
 
   template <std::size_t... Is>
   auto subscripts(std::ptrdiff_t const index,
                   detail::index_sequence<Is...>) const -> const_references
   {
-    return std::tie(*std::next(std::get<Is>(views_).begin(), index)...);
+    return const_references(*std::next(std::get<Is>(views_).begin(), index)...);
   }
 
 public:
@@ -310,13 +310,13 @@ public:
     template <std::size_t... Is>
     auto dereference(detail::index_sequence<Is...>) -> deref_tuple<Is...>
     {
-      return std::tie(*std::get<Is>(iters_)...);
+      return deref_tuple<Is...>(*std::get<Is>(iters_)...);
     }
 
     template <std::size_t... Is>
     auto dereference(detail::index_sequence<Is...>) const -> deref_tuple<Is...>
     {
-      return std::tie(*std::get<Is>(iters_)...);
+      return deref_tuple<Is...>(*std::get<Is>(iters_)...);
     }
 
   public:

--- a/tests/algo.cpp
+++ b/tests/algo.cpp
@@ -1238,3 +1238,450 @@ SCENARIO("std::unique works on sorted zip_view", "[algorithms][unique]")
     }
   }
 }
+
+SCENARIO("Testing algorithms on nested zip_views", "[zip_view][nested][algo]")
+{
+  {
+    WHEN("Using std::for_each on nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2, 3};
+      std::vector<int> v2 = {4, 5, 6};
+      std::vector<int> v3 = {7, 8, 9};
+      std::vector<int> v4 = {10, 11, 12};
+
+      auto zip1   = gst::ranges::views::zip(v1, v2);
+      auto zip2   = gst::ranges::views::zip(v3, v4);
+      auto nested = gst::ranges::views::zip(zip1, zip2);
+
+      THEN("std::for_each can iterate and access nested elements")
+      {
+        int sum = 0;
+        std::for_each(nested.begin(),
+                      nested.end(),
+                      [&sum](auto elem)
+                      {
+                        auto t0  = std::get<0>(elem);
+                        sum     += std::get<0>(t0) + std::get<1>(t0);
+                      });
+        REQUIRE(sum == 21); // (1+4) + (2+5) + (3+6) = 21
+      }
+
+      THEN("std::for_each can modify elements through nested zip_view")
+      {
+        std::for_each(nested.begin(),
+                      nested.end(),
+                      [](auto&& elem)
+                      {
+                        auto t0          = std::get<0>(elem);
+                        std::get<0>(t0) *= 10;
+                      });
+        REQUIRE(v1 == std::vector<int>{10, 20, 30});
+      }
+    }
+
+    WHEN("Using std::count_if on nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2, 3, 4, 5};
+      std::vector<int> v2 = {2, 4, 6, 8, 10};
+      std::vector<int> v3 = {1, 3, 5, 7, 9};
+
+      auto nested = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+
+      THEN("std::count_if works on nested zip_views")
+      {
+        auto count = std::count_if(nested.begin(),
+                                   nested.end(),
+                                   [](auto elem)
+                                   {
+                                     auto t0 = std::get<0>(elem);
+                                     return std::get<0>(t0) > 2; // Count where v1 > 2
+                                   });
+        REQUIRE(count == 3);                                     // Elements 3, 4, 5
+      }
+
+      THEN("std::count_if with complex predicate on nested elements")
+      {
+        auto count = std::count_if(nested.begin(),
+                                   nested.end(),
+                                   [](auto elem)
+                                   {
+                                     auto t0      = std::get<0>(elem);
+                                     auto regular = std::get<1>(elem);
+                                     return std::get<1>(t0) % 4 == 0 &&
+                                            regular % 2 == 1; // v2 divisible by 4 AND v3 odd
+                                   });
+        REQUIRE(count == 2); // Positions 1 and 3 (v2=4,v3=3 and v2=8,v3=7)
+      }
+    }
+
+    WHEN("Using std::transform on nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2, 3};
+      std::vector<int> v2 = {10, 20, 30};
+      std::vector<int> v3 = {100, 200, 300};
+
+      auto zip1   = gst::ranges::views::zip(v1, v2);
+      auto zip2   = gst::ranges::views::zip(v2, v3);
+      auto nested = gst::ranges::views::zip(zip1, zip2);
+
+      std::vector<int> results;
+
+      THEN("std::transform can extract and combine nested elements")
+      {
+        std::transform(nested.begin(),
+                       nested.end(),
+                       std::back_inserter(results),
+                       [](auto elem)
+                       {
+                         auto t0 = std::get<0>(elem);
+                         auto t1 = std::get<1>(elem);
+                         return std::get<0>(t0) + std::get<1>(t1); // v1 + v3
+                       });
+        REQUIRE(results == std::vector<int>{101, 202, 303});
+      }
+    }
+
+    WHEN("Using std::any_of and std::all_of on nested zip_views")
+    {
+      std::vector<int> v1 = {2, 4, 6};
+      std::vector<int> v2 = {1, 3, 5};
+      std::vector<int> v3 = {10, 20, 30};
+
+      auto nested = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+
+      THEN("std::any_of works on nested zip_views")
+      {
+        bool has_even_in_first = std::any_of(nested.begin(),
+                                             nested.end(),
+                                             [](auto elem)
+                                             {
+                                               auto t0 = std::get<0>(elem);
+                                               return std::get<0>(t0) % 2 == 0;
+                                             });
+        REQUIRE(has_even_in_first);
+      }
+
+      THEN("std::all_of works on nested zip_views")
+      {
+        bool all_positive =
+          std::all_of(nested.begin(),
+                      nested.end(),
+                      [](auto elem)
+                      {
+                        auto t0 = std::get<0>(elem);
+                        return std::get<0>(t0) > 0 && std::get<1>(t0) > 0 && std::get<1>(elem) > 0;
+                      });
+        REQUIRE(all_positive);
+      }
+    }
+
+    WHEN("Using std::find_if on nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2, 3, 4, 5};
+      std::vector<int> v2 = {10, 20, 30, 40, 50};
+      std::vector<int> v3 = {5, 4, 3, 2, 1};
+
+      auto zip1   = gst::ranges::views::zip(v1, v2);
+      auto zip2   = gst::ranges::views::zip(v2, v3);
+      auto nested = gst::ranges::views::zip(zip1, zip2);
+
+      THEN("std::find_if can locate specific nested elements")
+      {
+        auto it = std::find_if(nested.begin(),
+                               nested.end(),
+                               [](auto elem)
+                               {
+                                 auto t0 = std::get<0>(elem);
+                                 return std::get<0>(t0) == 3;
+                               });
+
+        REQUIRE(it != nested.end());
+        auto found = *it;
+        auto t0    = std::get<0>(found);
+        REQUIRE(std::get<1>(t0) == 30);
+      }
+    }
+
+    WHEN("Using std::accumulate on nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2, 3};
+      std::vector<int> v2 = {4, 5, 6};
+      std::vector<int> v3 = {7, 8, 9};
+
+      auto nested = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+
+      THEN("std::accumulate can sum nested elements")
+      {
+        int sum = std::accumulate(nested.begin(),
+                                  nested.end(),
+                                  0,
+                                  [](int acc, auto elem)
+                                  {
+                                    auto t0 = std::get<0>(elem);
+                                    return acc + std::get<0>(t0) + std::get<1>(elem);
+                                  });
+        REQUIRE(sum == 30); // (1+7) + (2+8) + (3+9) = 8 + 10 + 12 = 30
+      }
+    }
+
+    WHEN("Using std::copy_if with nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2, 3, 4, 5};
+      std::vector<int> v2 = {10, 20, 30, 40, 50};
+      std::vector<int> v3 = {2, 4, 6, 8, 10};
+
+      auto             nested = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+      std::vector<int> selected;
+
+      THEN("std::copy_if can filter and extract from nested zip_views")
+      {
+        std::for_each(nested.begin(),
+                      nested.end(),
+                      [&selected](auto elem)
+                      {
+                        auto t0 = std::get<0>(elem);
+                        if (std::get<0>(t0) > 2)
+                        { // Copy v1 values > 2
+                          selected.push_back(std::get<0>(t0));
+                        }
+                      });
+        REQUIRE(selected == std::vector<int>{3, 4, 5});
+      }
+    }
+  }
+
+  GIVEN("Algorithms with temporary nested zip_views")
+  {
+    WHEN("Using std::for_each on inline temporary nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2, 3, 4};
+      std::vector<int> v2 = {10, 20, 30, 40};
+      std::vector<int> v3 = {100, 200, 300, 400};
+      std::vector<int> v4 = {5, 6, 7, 8};
+
+      THEN("Can apply std::for_each directly to temporary nested zip_view")
+      {
+        int sum = 0;
+        std::for_each(
+          gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), gst::ranges::views::zip(v3, v4))
+            .begin(),
+          gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), gst::ranges::views::zip(v3, v4))
+            .end(),
+          [&sum](auto elem)
+          {
+            auto t0  = std::get<0>(elem);
+            auto t1  = std::get<1>(elem);
+            sum     += std::get<0>(t0) + std::get<0>(t1);
+          });
+        REQUIRE(sum == 1010); // (1+100) + (2+200) + (3+300) + (4+400) = 1010
+      }
+
+      THEN("Can modify through std::for_each on temporary nested zip_view")
+      {
+        std::for_each(gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v4).begin(),
+                      gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v4).end(),
+                      [](auto&& elem)
+                      {
+                        auto t0          = std::get<0>(elem);
+                        std::get<1>(t0) *= 2;
+                      });
+        REQUIRE(v2 == std::vector<int>{20, 40, 60, 80});
+      }
+    }
+
+    WHEN("Using std::count_if on inline temporary nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2, 3, 4, 5};
+      std::vector<int> v2 = {2, 4, 6, 8, 10};
+      std::vector<int> v3 = {10, 20, 30, 40, 50};
+
+      THEN("std::count_if works directly on temporary nested zip_view")
+      {
+        auto count =
+          std::count_if(gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3).begin(),
+                        gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3).end(),
+                        [](auto elem)
+                        {
+                          auto t0 = std::get<0>(elem);
+                          return std::get<0>(t0) > 2 && std::get<1>(t0) % 4 == 0;
+                        });
+        REQUIRE(count == 1); // v1 > 2 AND v2 divisible by 4: only (4,8)
+      }
+    }
+
+    WHEN("Using std::any_of on inline temporary nested zip_views")
+    {
+      std::vector<int> v1 = {1, 3, 5, 7};
+      std::vector<int> v2 = {2, 4, 6, 8};
+      std::vector<int> v3 = {10, 20, 30, 40};
+
+      THEN("std::any_of works on temporary nested zip_view")
+      {
+        bool has_sum_greater_than_50 =
+          std::any_of(gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3).begin(),
+                      gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3).end(),
+                      [](auto elem)
+                      {
+                        auto t0 = std::get<0>(elem);
+                        return std::get<0>(t0) + std::get<1>(t0) + std::get<1>(elem) > 50;
+                      });
+        REQUIRE(has_sum_greater_than_50); // 7 + 8 + 40 = 55 > 50
+      }
+    }
+
+    WHEN("Using std::transform on inline temporary nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2, 3};
+      std::vector<int> v2 = {4, 5, 6};
+      std::vector<int> v3 = {7, 8, 9};
+      std::vector<int> v4 = {10, 11, 12};
+      std::vector<int> results;
+
+      THEN("std::transform works on temporary nested zip_view")
+      {
+        std::transform(
+          gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), gst::ranges::views::zip(v3, v4))
+            .begin(),
+          gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), gst::ranges::views::zip(v3, v4))
+            .end(),
+          std::back_inserter(results),
+          [](auto elem)
+          {
+            auto t0 = std::get<0>(elem);
+            auto t1 = std::get<1>(elem);
+            return std::get<0>(t0) + std::get<1>(t0) + std::get<0>(t1) + std::get<1>(t1);
+          });
+        REQUIRE(results == std::vector<int>{22, 26, 30}); // (1+4+7+10), (2+5+8+11), (3+6+9+12)
+      }
+    }
+
+    WHEN("Using std::find_if on inline temporary nested zip_views")
+    {
+      std::vector<int> v1 = {10, 20, 30, 40, 50};
+      std::vector<int> v2 = {1, 2, 3, 4, 5};
+      std::vector<int> v3 = {5, 4, 3, 2, 1};
+
+      THEN("std::find_if locates element in temporary nested zip_view")
+      {
+        auto temp_zip = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+        auto it       = std::find_if(temp_zip.begin(),
+                               temp_zip.end(),
+                               [](auto elem)
+                               {
+                                 auto t0 = std::get<0>(elem);
+                                 return std::get<0>(t0) == 30;
+                               });
+
+        REQUIRE(it != temp_zip.end());
+        auto found = *it;
+        auto t0    = std::get<0>(found);
+        REQUIRE(std::get<1>(t0) == 3);
+        REQUIRE(std::get<1>(found) == 3);
+      }
+    }
+
+    WHEN("Using std::accumulate on inline temporary nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2, 3};
+      std::vector<int> v2 = {10, 20, 30};
+      std::vector<int> v3 = {100, 200, 300};
+
+      THEN("std::accumulate works on temporary nested zip_view")
+      {
+        auto temp    = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+        int  product = std::accumulate(temp.begin(),
+                                      temp.end(),
+                                      1,
+                                      [](int acc, auto elem)
+                                      {
+                                        auto t0 = std::get<0>(elem);
+                                        return acc * std::get<0>(t0); // Multiply all v1 values
+                                      });
+        REQUIRE(product == 6);                                         // 1 * 2 * 3 = 6
+      }
+    }
+
+    WHEN("Using std::all_of on inline temporary deeply nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2, 3};
+      std::vector<int> v2 = {4, 5, 6};
+      std::vector<int> v3 = {7, 8, 9};
+      std::vector<int> v4 = {10, 11, 12};
+      std::vector<int> v5 = {2, 2, 2};
+
+      THEN("std::all_of works on deeply nested temporary zip_view")
+      {
+        bool all_positive = std::all_of(
+          gst::ranges::views::zip(gst::ranges::views::zip(gst::ranges::views::zip(v1, v2),
+                                                          gst::ranges::views::zip(v3, v4)),
+                                  v5)
+            .begin(),
+          gst::ranges::views::zip(gst::ranges::views::zip(gst::ranges::views::zip(v1, v2),
+                                                          gst::ranges::views::zip(v3, v4)),
+                                  v5)
+            .end(),
+          [](auto elem)
+          {
+            return std::get<1>(elem) > 0; // Check v5 elements all > 0
+          });
+        REQUIRE(all_positive);
+      }
+    }
+
+    WHEN("Using multiple algorithms in sequence on temporary nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2, 3, 4, 5};
+      std::vector<int> v2 = {10, 20, 30, 40, 50};
+      std::vector<int> v3 = {5, 4, 3, 2, 1};
+
+      THEN("Can chain multiple algorithm operations on temporary nested zip_view")
+      {
+        auto temp = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+
+        // First: count elements where v1 > 2
+        auto count = std::count_if(temp.begin(),
+                                   temp.end(),
+                                   [](auto elem)
+                                   {
+                                     auto t0 = std::get<0>(elem);
+                                     return std::get<0>(t0) > 2;
+                                   });
+        REQUIRE(count == 3);
+
+        // Second: find first where v3 < 3
+        auto it =
+          std::find_if(temp.begin(), temp.end(), [](auto elem) { return std::get<1>(elem) < 3; });
+        REQUIRE(it != temp.end());
+
+        // Third: accumulate sum of v2 values
+        int sum = std::accumulate(temp.begin(),
+                                  temp.end(),
+                                  0,
+                                  [](int acc, auto elem)
+                                  {
+                                    auto t0 = std::get<0>(elem);
+                                    return acc + std::get<1>(t0);
+                                  });
+        REQUIRE(sum == 150); // 10+20+30+40+50
+      }
+    }
+
+    WHEN("Using range-based for directly on temporary nested zip_views in algorithm context")
+    {
+      std::vector<int> v1 = {1, 2, 3};
+      std::vector<int> v2 = {4, 5, 6};
+      std::vector<int> v3 = {7, 8, 9};
+
+      THEN("Can use range-based for on temporary created inline")
+      {
+        int sum = 0;
+        for (auto elem : gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3))
+        {
+          auto t0  = std::get<0>(elem);
+          sum     += std::get<0>(t0) + std::get<1>(elem);
+        }
+        REQUIRE(sum == 30); // (1+7) + (2+8) + (3+9) = 30
+      }
+    }
+  }
+}

--- a/tests/algo.cpp
+++ b/tests/algo.cpp
@@ -1366,11 +1366,7 @@ SCENARIO("Testing algorithms on nested zip_views", "[zip_view][nested][algo]")
         bool all_positive =
           std::all_of(nested.begin(),
                       nested.end(),
-                      [](auto elem)
-                      {
-                        auto t0 = std::get<0>(elem);
-                        return std::get<0>(t0) > 0 && std::get<1>(t0) > 0 && std::get<1>(elem) > 0;
-                      });
+                      [](auto elem) { return std::get<0>(elem) > std::make_tuple(0, 0); });
         REQUIRE(all_positive);
       }
     }

--- a/tests/base.cpp
+++ b/tests/base.cpp
@@ -474,3 +474,474 @@ SCENARIO("Testing assignment operators", "[zip_view]")
     }
   }
 }
+
+SCENARIO("Testing nested zip_views (zip of zip_views)", "[zip_view][nested]")
+{
+  {
+    GIVEN("Empty zip_views")
+    {
+      std::vector<int>  v1 = {};
+      std::vector<int>  v2 = {};
+      std::vector<char> v3 = {};
+      std::vector<char> v4 = {};
+
+      auto zip1 = gst::ranges::views::zip(v1, v2);
+      auto zip2 = gst::ranges::views::zip(v3, v4);
+
+      WHEN("Zipping two empty zip_views")
+      {
+        auto nested = gst::ranges::views::zip(zip1, zip2);
+
+        THEN("The nested zip_view is empty")
+        {
+          REQUIRE(nested.empty());
+          REQUIRE(nested.size() == 0);
+          REQUIRE(nested.begin() == nested.end());
+        }
+      }
+    }
+
+    GIVEN("A single zip_view with other containers")
+    {
+      std::vector<int>   v1 = {1, 2, 3};
+      std::vector<int>   v2 = {4, 5, 6};
+      std::vector<float> v3 = {1.1F, 2.2F, 3.3F};
+
+      auto zip1 = gst::ranges::views::zip(v1, v2);
+
+      WHEN("Zipping one zip_view with a regular container")
+      {
+        auto nested = gst::ranges::views::zip(zip1, v3);
+
+        THEN("The nested zip_view has correct size") { REQUIRE(nested.size() == 3); }
+
+        THEN("Can iterate through nested zip_view")
+        {
+          int count = 0;
+          for (auto it = nested.begin(); it != nested.end(); ++it) { ++count; }
+          REQUIRE(count == 3);
+        }
+
+        THEN("Can access and verify size")
+        {
+          REQUIRE(zip1.size() == 3);
+          REQUIRE(nested.size() == 3);
+          REQUIRE_FALSE(nested.empty());
+        }
+
+        THEN("Can access elements correctly using iterators")
+        {
+          auto it     = nested.begin();
+          auto elem0  = *it;
+          auto tuple0 = std::get<0>(elem0);
+          REQUIRE(std::get<0>(tuple0) == 1);
+          REQUIRE(std::get<1>(tuple0) == 4);
+          REQUIRE(std::get<1>(elem0) > 1.0F);
+          REQUIRE(std::get<1>(elem0) < 1.2F);
+
+          ++it;
+          auto elem1  = *it;
+          auto tuple1 = std::get<0>(elem1);
+          REQUIRE(std::get<0>(tuple1) == 2);
+          REQUIRE(std::get<1>(tuple1) == 5);
+          REQUIRE(std::get<1>(elem1) > 2.1F);
+          REQUIRE(std::get<1>(elem1) < 2.3F);
+        }
+
+        THEN("Can modify regular container elements through nested zip_view")
+        {
+          auto it          = nested.begin();
+          std::get<1>(*it) = 9.9F;
+          REQUIRE(v3[0] > 9.8F);
+          REQUIRE(v3[0] < 10.0F);
+        }
+      }
+    }
+
+    GIVEN("Multiple zip_views of the same length")
+    {
+      std::vector<int>  v1 = {1, 2, 3, 4};
+      std::vector<int>  v2 = {5, 6, 7, 8};
+      std::vector<char> v3 = {'a', 'b', 'c', 'd'};
+      std::vector<char> v4 = {'w', 'x', 'y', 'z'};
+      std::list<float>  v5 = {1.1F, 2.2F, 3.3F, 4.4F};
+      std::list<float>  v6 = {5.5F, 6.6F, 7.7F, 8.8F};
+
+      auto zip1 = gst::ranges::views::zip(v1, v2);
+      auto zip2 = gst::ranges::views::zip(v3, v4);
+      auto zip3 = gst::ranges::views::zip(v5, v6);
+
+      WHEN("Zipping three zip_views together")
+      {
+        auto nested = gst::ranges::views::zip(zip1, zip2, zip3);
+
+        THEN("The nested zip_view has correct size") { REQUIRE(nested.size() == 4); }
+
+        THEN("Can iterate and access all elements")
+        {
+          auto it    = nested.begin();
+          auto elem0 = *it;
+          REQUIRE((std::get<0>(elem0) == std::make_tuple(1, 5)));
+          REQUIRE((std::get<1>(elem0) == std::make_tuple('a', 'w')));
+          REQUIRE((std::get<2>(elem0) == std::make_tuple(1.1F, 5.5F)));
+
+          std::advance(it, 2);
+          auto elem2 = *it;
+          REQUIRE((std::get<0>(elem2) == std::make_tuple(3, 7)));
+          REQUIRE((std::get<1>(elem2) == std::make_tuple('c', 'y')));
+          REQUIRE((std::get<2>(elem2) == std::make_tuple(3.3F, 7.7F)));
+        }
+
+        THEN("Can modify all underlying containers through nested zip_view")
+        {
+          for (auto&& elem : nested)
+          {
+            std::get<0>(std::get<0>(elem)) += 100;
+            std::get<1>(std::get<1>(elem))  = 'Z';
+            std::get<0>(std::get<2>(elem)) += 10.0F;
+          }
+
+          REQUIRE(v1[0] == 101);
+          REQUIRE(v1[3] == 104);
+          REQUIRE(v4[0] == 'Z');
+          REQUIRE(v4[3] == 'Z');
+          REQUIRE(v5.front() > 11.0F);
+          REQUIRE(v5.front() < 11.2F);
+          REQUIRE(v5.back() > 14.3F);
+          REQUIRE(v5.back() < 14.5F);
+        }
+      }
+    }
+
+    GIVEN("Multiple zip_views of different lengths")
+    {
+      std::vector<int>  v1 = {1, 2, 3, 4, 5};
+      std::vector<int>  v2 = {10, 20, 30, 40, 50};
+      std::vector<char> v3 = {'a', 'b', 'c'};
+      std::vector<char> v4 = {'x', 'y', 'z'};
+      std::deque<float> v5 = {1.1F, 2.2F};
+      std::deque<float> v6 = {9.9F, 8.8F};
+
+      auto zip1 = gst::ranges::views::zip(v1, v2);
+      auto zip2 = gst::ranges::views::zip(v3, v4);
+      auto zip3 = gst::ranges::views::zip(v5, v6);
+
+      WHEN("Zipping zip_views of different lengths")
+      {
+        auto nested = gst::ranges::views::zip(zip1, zip2, zip3);
+
+        THEN("Size is limited by shortest zip_view") { REQUIRE(nested.size() == 2); }
+
+        THEN("Can access elements up to shortest length")
+        {
+          auto it    = nested.begin();
+          auto elem0 = *it;
+          REQUIRE((std::get<0>(elem0) == std::make_tuple(1, 10)));
+          REQUIRE((std::get<1>(elem0) == std::make_tuple('a', 'x')));
+          REQUIRE((std::get<2>(elem0) == std::make_tuple(1.1F, 9.9F)));
+
+          ++it;
+          auto elem1 = *it;
+          REQUIRE((std::get<0>(elem1) == std::make_tuple(2, 20)));
+          REQUIRE((std::get<1>(elem1) == std::make_tuple('b', 'y')));
+          REQUIRE((std::get<2>(elem1) == std::make_tuple(2.2F, 8.8F)));
+        }
+
+        THEN("front() and back() work correctly")
+        {
+          auto front = nested.front();
+          REQUIRE((std::get<0>(front) == std::make_tuple(1, 10)));
+
+          auto back = nested.back();
+          REQUIRE((std::get<0>(back) == std::make_tuple(2, 20)));
+        }
+      }
+    }
+
+    GIVEN("Mixed: zip_views and regular containers")
+    {
+      std::vector<int>   v1 = {1, 2, 3};
+      std::vector<int>   v2 = {10, 20, 30};
+      std::vector<char>  v3 = {'a', 'b', 'c'};
+      std::vector<char>  v4 = {'x', 'y', 'z'};
+      std::vector<float> v5 = {1.1F, 2.2F, 3.3F};
+      std::list<double>  v6 = {100.0, 200.0, 300.0};
+
+      auto zip1 = gst::ranges::views::zip(v1, v2);
+      auto zip2 = gst::ranges::views::zip(v3, v4);
+
+      WHEN("Zipping mix of zip_views and regular containers")
+      {
+        auto mixed = gst::ranges::views::zip(zip1, v5, zip2, v6);
+
+        THEN("The mixed zip_view has correct size") { REQUIRE(mixed.size() == 3); }
+
+        THEN("Can iterate through mixed structure")
+        {
+          int count = 0;
+          for (auto it = mixed.begin(); it != mixed.end(); ++it) { ++count; }
+          REQUIRE(count == 3);
+        }
+
+        THEN("Can access regular container elements")
+        {
+          auto it = mixed.begin();
+          ++it;
+          auto elem1 = *it;
+          REQUIRE((std::get<0>(elem1) == std::make_tuple(2, 20)));
+          REQUIRE(std::get<1>(elem1) > 2.1F);
+          REQUIRE(std::get<1>(elem1) < 2.3F);
+          REQUIRE((std::get<2>(elem1) == std::make_tuple('b', 'y')));
+          REQUIRE(std::get<3>(elem1) > 199.0);
+          REQUIRE(std::get<3>(elem1) < 201.0);
+        }
+
+        THEN("Can modify regular container elements through mixed structure")
+        {
+          for (auto&& elem : mixed)
+          {
+            std::get<1>(std::get<0>(elem)) *= 10;
+            std::get<1>(elem)              += 100.0F;
+          }
+
+          REQUIRE(v2 == std::vector<int>{100, 200, 300});
+          REQUIRE(v5 == std::vector<float>{101.1F, 102.2F, 103.3F});
+        }
+      }
+    }
+
+    GIVEN("Nested zip_views with different container types")
+    {
+      std::array<int, 3> arr1 = {1, 2, 3};
+      std::list<int>     lst1 = {4, 5, 6};
+      std::deque<char>   deq1 = {'a', 'b', 'c'};
+      std::vector<char>  vec1 = {'x', 'y', 'z'};
+
+      auto zip1 = gst::ranges::views::zip(arr1, lst1);
+      auto zip2 = gst::ranges::views::zip(deq1, vec1);
+
+      WHEN("Zipping zip_views with different underlying container types")
+      {
+        auto nested = gst::ranges::views::zip(zip1, zip2);
+
+        THEN("Size matches shortest container") { REQUIRE(nested.size() == 3); }
+
+        THEN("front() returns first elements")
+        {
+          auto front = nested.front();
+          REQUIRE((std::get<0>(front) == std::make_tuple(1, 4)));
+          REQUIRE((std::get<1>(front) == std::make_tuple('a', 'x')));
+        }
+
+        THEN("back() returns last elements")
+        {
+          auto back = nested.back();
+          REQUIRE((std::get<0>(back) == std::make_tuple(3, 6)));
+          REQUIRE((std::get<1>(back) == std::make_tuple('c', 'z')));
+        }
+
+        THEN("Can iterate with range-based for loop")
+        {
+          int count = 0;
+          for (auto elem : nested)
+          {
+            (void)elem;
+            ++count;
+          }
+          REQUIRE(count == 3);
+        }
+      }
+    }
+
+    GIVEN("Deeply nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2};
+      std::vector<int> v2 = {3, 4};
+      std::vector<int> v3 = {5, 6};
+      std::vector<int> v4 = {7, 8};
+
+      auto zip1 = gst::ranges::views::zip(v1, v2);
+      auto zip2 = gst::ranges::views::zip(v3, v4);
+      auto zip3 = gst::ranges::views::zip(zip1, zip2);
+
+      WHEN("Creating another zip from nested zip_views")
+      {
+        std::vector<int> v5   = {9, 10};
+        auto             zip4 = gst::ranges::views::zip(zip3, v5);
+
+        THEN("Deeply nested structure has correct size") { REQUIRE(zip4.size() == 2); }
+
+        THEN("Can access deeply nested elements")
+        {
+          auto it    = zip4.begin();
+          auto elem0 = *it;
+          REQUIRE(std::get<1>(elem0) == 9);
+
+          auto nested_tuple = std::get<0>(elem0);
+          REQUIRE((std::get<0>(nested_tuple) == std::make_tuple(1, 3)));
+          REQUIRE((std::get<1>(nested_tuple) == std::make_tuple(5, 7)));
+        }
+
+        THEN("Can modify through deep nesting")
+        {
+          auto it          = zip4.begin();
+          std::get<1>(*it) = 99;
+          REQUIRE(v5[0] == 99);
+        }
+
+        THEN("All nested structures have correct sizes")
+        {
+          REQUIRE(zip1.size() == 2);
+          REQUIRE(zip2.size() == 2);
+          REQUIRE(zip3.size() == 2);
+          REQUIRE(zip4.size() == 2);
+        }
+      }
+    }
+
+    GIVEN("Zip_views with one element each")
+    {
+      std::vector<int>  v1 = {42};
+      std::vector<int>  v2 = {84};
+      std::vector<char> v3 = {'X'};
+
+      auto zip1 = gst::ranges::views::zip(v1);
+      auto zip2 = gst::ranges::views::zip(v2, v3);
+
+      WHEN("Zipping single-element zip_views")
+      {
+        auto nested = gst::ranges::views::zip(zip1, zip2);
+
+        THEN("Size is 1") { REQUIRE(nested.size() == 1); }
+
+        THEN("Element is accessible")
+        {
+          auto it   = nested.begin();
+          auto elem = *it;
+          REQUIRE((std::get<0>(elem) == std::make_tuple(42)));
+          REQUIRE((std::get<1>(elem) == std::make_tuple(84, 'X')));
+        }
+
+        THEN("Can iterate once")
+        {
+          int count = 0;
+          for (auto it = nested.begin(); it != nested.end(); ++it) { ++count; }
+          REQUIRE(count == 1);
+        }
+      }
+    }
+
+    GIVEN("Comparison with std::ranges::zip_view")
+    {
+      std::vector<int> v1 = {1, 2, 3};
+      std::vector<int> v2 = {4, 5, 6};
+      std::vector<int> v3 = {7, 8, 9};
+      std::vector<int> v4 = {10, 11, 12};
+
+      auto gst_zip1 = gst::ranges::views::zip(v1, v2, v3);
+      auto gst_zip2 = gst::ranges::views::zip(v2, v3, v4);
+      auto gst_zip3 = gst::ranges::views::zip(v4, v1, v2);
+      auto std_zip1 = std::ranges::views::zip(v1, v2, v3);
+      auto std_zip2 = std::ranges::views::zip(v2, v3, v4);
+      auto std_zip3 = std::ranges::views::zip(v4, v1, v2);
+
+      WHEN("Comparing nested gst::zip_view with std::ranges::zip_view")
+      {
+        auto gst_nested = gst::ranges::views::zip(gst_zip1, gst_zip2, gst_zip3);
+        auto std_nested = std::ranges::views::zip(std_zip1, std_zip2, std_zip3);
+
+        THEN("Sizes match") { REQUIRE(gst_nested.size() == std_nested.size()); }
+
+        THEN("Elements match")
+        {
+          auto gst_it = gst_nested.begin();
+          auto std_it = std_nested.begin();
+
+          while (gst_it != gst_nested.end() && std_it != std_nested.end())
+          {
+            REQUIRE((*gst_it == *std_it));
+            ++gst_it;
+            ++std_it;
+          }
+          REQUIRE(gst_it == gst_nested.end());
+          REQUIRE(std_it == std_nested.end());
+        }
+      }
+    }
+
+    GIVEN("Very large nested zip_views")
+    {
+      std::vector<int> v1(10'000, 1);
+      std::vector<int> v2(10'000, 2);
+      std::vector<int> v3(10'000, 3);
+      std::vector<int> v4(10'000, 4);
+
+      auto zip1 = gst::ranges::views::zip(v1, v2);
+      auto zip2 = gst::ranges::views::zip(v3, v4);
+
+      WHEN("Creating large nested zip_views")
+      {
+        auto nested = gst::ranges::views::zip(zip1, zip2);
+
+        THEN("Size is correct") { REQUIRE(nested.size() == 10'000); }
+
+        THEN("Can iterate through all elements")
+        {
+          int count = 0;
+          for (auto it = nested.begin(); it != nested.end(); ++it)
+          {
+            ++count;
+            if (count >= 100) break;
+          }
+          REQUIRE(count == 100);
+        }
+
+        THEN("Can access and modify elements")
+        {
+          auto elem = nested[5000];
+          REQUIRE((std::get<0>(elem) == std::make_tuple(1, 2)));
+          REQUIRE((std::get<1>(elem) == std::make_tuple(3, 4)));
+
+          std::get<0>(std::get<0>(elem)) = 999;
+          REQUIRE(v1[5000] == 999);
+        }
+      }
+    }
+
+    GIVEN("Multiple levels of nesting")
+    {
+      std::vector<int> v1 = {1, 2, 3};
+      std::vector<int> v2 = {4, 5, 6};
+      std::vector<int> v3 = {7, 8, 9};
+      std::vector<int> v4 = {10, 11, 12};
+      std::vector<int> v5 = {13, 14, 15};
+      std::vector<int> v6 = {16, 17, 18};
+
+      WHEN("Creating multiple levels of nested zip_views")
+      {
+        auto zip1 = gst::ranges::views::zip(v1, v2);
+        auto zip2 = gst::ranges::views::zip(v3, v4);
+        auto zip3 = gst::ranges::views::zip(v5, v6);
+
+        auto level1 = gst::ranges::views::zip(zip1, zip2);
+        auto level2 = gst::ranges::views::zip(level1, zip3);
+
+        THEN("All levels have correct sizes")
+        {
+          REQUIRE(zip1.size() == 3);
+          REQUIRE(zip2.size() == 3);
+          REQUIRE(zip3.size() == 3);
+          REQUIRE(level1.size() == 3);
+          REQUIRE(level2.size() == 3);
+        }
+
+        THEN("Can iterate through multiple levels")
+        {
+          int count = 0;
+          for (auto it = level2.begin(); it != level2.end(); ++it) { ++count; }
+          REQUIRE(count == 3);
+        }
+      }
+    }
+  }
+}

--- a/tests/base.cpp
+++ b/tests/base.cpp
@@ -9,7 +9,8 @@
 #include <catch2/catch_test_macros.hpp>
 #endif
 
-#include <algorithm>
+#include <catch2/catch_approx.hpp>
+
 #include <array>
 #include <deque>
 #include <forward_list>
@@ -20,6 +21,33 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+SCENARIO("zip_view with various container combinations", "[zip_view]")
+{
+  GIVEN("Two vectors of int and char")
+  {
+    std::vector<int>  vec1 = {1, 2, 3};
+    std::vector<char> vec2 = {'a', 'b', 'c'};
+
+    auto gst_zipped = gst::ranges::views::zip(vec1, vec2);
+    auto std_zipped = std::ranges::views::zip(vec1, vec2);
+
+    THEN("The sizes match") { REQUIRE(gst_zipped.size() == std_zipped.size()); }
+    THEN("The view is not empty") { REQUIRE_FALSE(gst_zipped.empty()); }
+  }
+
+  GIVEN("Two vectors of same type")
+  {
+    std::vector<int> vec1 = {1, 2, 3};
+    std::vector<int> vec2 = {4, 5, 6};
+
+    auto gst_zipped = gst::ranges::views::zip(vec1, vec2);
+    auto std_zipped = std::ranges::views::zip(vec1, vec2);
+
+    THEN("The sizes match") { REQUIRE(gst_zipped.size() == std_zipped.size()); }
+    THEN("The view is not empty") { REQUIRE_FALSE(gst_zipped.empty()); }
+  }
+}
 
 SCENARIO("Comparing zip_view with std::ranges::zip_view using different containers and lengths",
          "[zip_view]")
@@ -536,24 +564,21 @@ SCENARIO("Testing nested zip_views (zip of zip_views)", "[zip_view][nested]")
           auto tuple0 = std::get<0>(elem0);
           REQUIRE(std::get<0>(tuple0) == 1);
           REQUIRE(std::get<1>(tuple0) == 4);
-          REQUIRE(std::get<1>(elem0) > 1.0F);
-          REQUIRE(std::get<1>(elem0) < 1.2F);
+          REQUIRE(std::get<1>(elem0) == Catch::Approx(1.1F));
 
           ++it;
           auto elem1  = *it;
           auto tuple1 = std::get<0>(elem1);
           REQUIRE(std::get<0>(tuple1) == 2);
           REQUIRE(std::get<1>(tuple1) == 5);
-          REQUIRE(std::get<1>(elem1) > 2.1F);
-          REQUIRE(std::get<1>(elem1) < 2.3F);
+          REQUIRE(std::get<1>(elem1) == Catch::Approx(2.2F));
         }
 
         THEN("Can modify regular container elements through nested zip_view")
         {
           auto it          = nested.begin();
           std::get<1>(*it) = 9.9F;
-          REQUIRE(v3[0] > 9.8F);
-          REQUIRE(v3[0] < 10.0F);
+          REQUIRE(v3[0] == Catch::Approx(9.9F));
         }
       }
     }
@@ -605,10 +630,8 @@ SCENARIO("Testing nested zip_views (zip of zip_views)", "[zip_view][nested]")
           REQUIRE(v1[3] == 104);
           REQUIRE(v4[0] == 'Z');
           REQUIRE(v4[3] == 'Z');
-          REQUIRE(v5.front() > 11.0F);
-          REQUIRE(v5.front() < 11.2F);
-          REQUIRE(v5.back() > 14.3F);
-          REQUIRE(v5.back() < 14.5F);
+          REQUIRE(v5.front() == Catch::Approx(11.1F));
+          REQUIRE(v5.back() == Catch::Approx(14.4F));
         }
       }
     }
@@ -689,11 +712,9 @@ SCENARIO("Testing nested zip_views (zip of zip_views)", "[zip_view][nested]")
           ++it;
           auto elem1 = *it;
           REQUIRE((std::get<0>(elem1) == std::make_tuple(2, 20)));
-          REQUIRE(std::get<1>(elem1) > 2.1F);
-          REQUIRE(std::get<1>(elem1) < 2.3F);
+          REQUIRE(std::get<1>(elem1) == Catch::Approx(2.2F));
           REQUIRE((std::get<2>(elem1) == std::make_tuple('b', 'y')));
-          REQUIRE(std::get<3>(elem1) > 199.0);
-          REQUIRE(std::get<3>(elem1) < 201.0);
+          REQUIRE(std::get<3>(elem1) == Catch::Approx(200.0));
         }
 
         THEN("Can modify regular container elements through mixed structure")

--- a/tests/edge.cpp
+++ b/tests/edge.cpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <deque>
 #include <list>
+#include <numeric>
 #include <ranges>
 #include <string>
 #include <tuple>

--- a/tests/edge.cpp
+++ b/tests/edge.cpp
@@ -9,11 +9,9 @@
 #include <catch2/catch_test_macros.hpp>
 #endif
 
-#include <algorithm>
 #include <array>
 #include <deque>
 #include <list>
-#include <numeric>
 #include <ranges>
 #include <string>
 #include <tuple>
@@ -114,7 +112,7 @@ SCENARIO("Testing gst::ranges::zip_view with edge scenarios", "[edge]")
       int   a;
       char  b;
       float c;
-      bool  operator==(Custom const& other) const
+      auto  operator==(Custom const& other) const -> bool
       {
         return std::equal_to{}(std::tie(a, b, c), std::tie(other.a, other.b, other.c));
       }

--- a/tests/iter.cpp
+++ b/tests/iter.cpp
@@ -10,13 +10,11 @@
 #endif
 #include <catch2/catch_approx.hpp>
 
-#include <algorithm>
 #include <array>
 #include <deque>
 #include <forward_list>
 #include <iterator>
 #include <list>
-#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -244,6 +242,39 @@ SCENARIO("zip_view iterator default constructor", "[iterator]")
       typename decltype(zipped)::iterator it1;
       typename decltype(zipped)::iterator it2;
       REQUIRE(it1 == it2);
+    }
+  }
+}
+
+SCENARIO("zip_view iterator inequality comparison", "[iterator]")
+{
+  GIVEN("A zip_view over three vectors")
+  {
+    std::vector<int>  vec1 = {1, 2, 3, 4, 5};
+    std::vector<char> vec2 = {'a', 'b', 'c', 'd', 'e'};
+    std::vector<int>  vec3 = {10, 20, 30, 40, 50};
+
+    auto zipped = gst::ranges::views::zip(vec1, vec2, vec3);
+
+    THEN("iterators at different positions compare unequal")
+    {
+      auto it1 = zipped.begin();
+      auto it2 = zipped.begin();
+      ++it2;
+
+      REQUIRE(it1 != it2);
+      REQUIRE_FALSE(it1 == it2);
+    }
+
+    THEN("iterators at far apart positions compare unequal")
+    {
+      auto it1 = zipped.begin();
+      auto it2 = zipped.begin();
+      ++it2;
+      ++it2;
+      ++it2;
+
+      REQUIRE(it1 != it2);
     }
   }
 }

--- a/tests/temp.cpp
+++ b/tests/temp.cpp
@@ -34,10 +34,12 @@ SCENARIO("zip_view with non-empty temporaries", "[temporaries]")
 {
   GIVEN("zip_view from temporaries")
   {
-    auto const gst_zip =
-      gst::ranges::views::zip(std::array<int, 3>{1, 2, 3}, std::list<char>{'a', 'b', 'c'});
-    auto const std_zip =
-      std::ranges::views::zip(std::array<int, 3>{1, 2, 3}, std::list<char>{'a', 'b', 'c'});
+    auto const gst_zip = gst::ranges::views::zip(std::array<int, 3>{1, 2, 3},
+                                                 std::list<char>{'a', 'b', 'c'},
+                                                 std::vector<float>{1.1F, 2.2F, 3.3F});
+    auto const std_zip = std::ranges::views::zip(std::array<int, 3>{1, 2, 3},
+                                                 std::list<char>{'a', 'b', 'c'},
+                                                 std::vector<float>{1.1F, 2.2F, 3.3F});
 
     THEN("emptiness matches std::ranges::zip_view") { REQUIRE(gst_zip.empty() == std_zip.empty()); }
     THEN("size matches std::ranges::zip_view") { REQUIRE(gst_zip.size() == std_zip.size()); }
@@ -45,11 +47,7 @@ SCENARIO("zip_view with non-empty temporaries", "[temporaries]")
     {
       auto gst_it = gst_zip.begin();
       auto std_it = std_zip.begin();
-      for (; gst_it != gst_zip.end(); ++gst_it, ++std_it)
-      {
-        REQUIRE(std::get<0>(*gst_it) == std::get<0>(*std_it));
-        REQUIRE(std::get<1>(*gst_it) == std::get<1>(*std_it));
-      }
+      for (; gst_it != gst_zip.end(); ++gst_it, ++std_it) { REQUIRE((*gst_it == *std_it)); }
       REQUIRE(std_it == std_zip.end());
     }
   }
@@ -108,20 +106,18 @@ SCENARIO("const zip_view from temporaries matches std", "[temporaries]")
 {
   GIVEN("const zip_view from temporaries")
   {
-    auto const gst_zip =
-      gst::ranges::views::zip(std::array<int, 3>{1, 2, 3}, std::vector<char>{'a', 'b', 'c'});
-    auto const std_zip =
-      std::ranges::views::zip(std::array<int, 3>{1, 2, 3}, std::vector<char>{'a', 'b', 'c'});
+    auto const gst_zip = gst::ranges::views::zip(std::array<int, 3>{1, 2, 3},
+                                                 std::vector<char>{'a', 'b', 'c'},
+                                                 std::list<double>{1.1, 2.2, 3.3});
+    auto const std_zip = std::ranges::views::zip(std::array<int, 3>{1, 2, 3},
+                                                 std::vector<char>{'a', 'b', 'c'},
+                                                 std::list<double>{1.1, 2.2, 3.3});
 
     THEN("elements match std::ranges::zip_view")
     {
       auto gst_it = gst_zip.begin();
       auto std_it = std_zip.begin();
-      for (; gst_it != gst_zip.end(); ++gst_it, ++std_it)
-      {
-        REQUIRE(std::get<0>(*gst_it) == std::get<0>(*std_it));
-        REQUIRE(std::get<1>(*gst_it) == std::get<1>(*std_it));
-      }
+      for (; gst_it != gst_zip.end(); ++gst_it, ++std_it) { REQUIRE((*gst_it == *std_it)); }
       REQUIRE(std_it == std_zip.end());
     }
   }
@@ -197,6 +193,301 @@ SCENARIO("zip_view inline usage with STL algorithms", "[temporaries]")
         0,
         [](int acc, auto const& t) { return acc + (std::get<0>(t) * std::get<1>(t)); });
       REQUIRE(dot == (1 * 'a' + 2 * 'b' + 3 * 'c'));
+    }
+  }
+}
+
+SCENARIO("Testing nested zip_views with temporaries", "[zip_view][nested][temp]")
+{
+  {
+    WHEN("Zipping temporary zip_views directly")
+    {
+      std::vector<int> v1 = {1, 2, 3};
+      std::vector<int> v2 = {4, 5, 6};
+      std::vector<int> v3 = {7, 8, 9};
+      std::vector<int> v4 = {10, 11, 12};
+
+      auto nested =
+        gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), gst::ranges::views::zip(v3, v4));
+
+      THEN("Nested temporary zip_view has correct size") { REQUIRE(nested.size() == 3); }
+
+      THEN("Can dereference and access elements")
+      {
+        auto it   = nested.begin();
+        auto elem = *it;
+        auto t0   = std::get<0>(elem);
+        auto t1   = std::get<1>(elem);
+        REQUIRE(std::get<0>(t0) == 1);
+        REQUIRE(std::get<1>(t0) == 4);
+        REQUIRE(std::get<0>(t1) == 7);
+        REQUIRE(std::get<1>(t1) == 10);
+      }
+
+      THEN("Can iterate through all elements")
+      {
+        int count = 0;
+        for (auto it = nested.begin(); it != nested.end(); ++it) { ++count; }
+        REQUIRE(count == 3);
+      }
+    }
+
+    WHEN("Zipping mix of temporary and stored zip_views")
+    {
+      std::vector<int>  v1 = {1, 2, 3};
+      std::vector<int>  v2 = {4, 5, 6};
+      std::vector<char> v3 = {'a', 'b', 'c'};
+      std::vector<char> v4 = {'x', 'y', 'z'};
+
+      auto zip1 = gst::ranges::views::zip(v1, v2);
+
+      auto mixed = gst::ranges::views::zip(zip1, gst::ranges::views::zip(v3, v4));
+
+      THEN("Mixed temporary structure has correct size") { REQUIRE(mixed.size() == 3); }
+
+      THEN("Can access elements from both stored and temporary zip_views")
+      {
+        auto it     = mixed.begin();
+        auto elem   = *it;
+        auto tuple0 = std::get<0>(elem);
+        auto tuple1 = std::get<1>(elem);
+        REQUIRE(std::get<0>(tuple0) == 1);
+        REQUIRE(std::get<1>(tuple0) == 4);
+        REQUIRE(std::get<0>(tuple1) == 'a');
+        REQUIRE(std::get<1>(tuple1) == 'x');
+      }
+    }
+
+    WHEN("Creating deeply nested temporary zip_views")
+    {
+      std::vector<int> v1 = {1, 2};
+      std::vector<int> v2 = {3, 4};
+      std::vector<int> v3 = {5, 6};
+      std::vector<int> v4 = {7, 8};
+      std::vector<int> v5 = {9, 10};
+
+      auto deep = gst::ranges::views::zip(
+        gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), gst::ranges::views::zip(v3, v4)),
+        v5);
+
+      THEN("Deep nesting with temporaries has correct size") { REQUIRE(deep.size() == 2); }
+
+      THEN("Can iterate through deeply nested temporaries")
+      {
+        int count = 0;
+        for (auto it = deep.begin(); it != deep.end(); ++it) { ++count; }
+        REQUIRE(count == 2);
+      }
+
+      THEN("Can access deeply nested elements")
+      {
+        auto it      = deep.begin();
+        auto elem    = *it;
+        auto nested1 = std::get<0>(elem);
+        auto nested2 = std::get<0>(nested1);
+        auto nested3 = std::get<1>(nested1);
+        auto regular = std::get<1>(elem);
+
+        REQUIRE(std::get<0>(nested2) == 1);
+        REQUIRE(std::get<1>(nested2) == 3);
+        REQUIRE(std::get<0>(nested3) == 5);
+        REQUIRE(std::get<1>(nested3) == 7);
+        REQUIRE(regular == 9);
+      }
+    }
+
+    WHEN("Zipping temporary containers through temporary zip_views")
+    {
+      auto nested = gst::ranges::views::zip(
+        gst::ranges::views::zip(std::vector<int>{1, 2, 3}, std::vector<int>{4, 5, 6}),
+        gst::ranges::views::zip(std::vector<char>{'a', 'b', 'c'},
+                                std::vector<char>{'x', 'y', 'z'}));
+
+      THEN("Temporary containers in temporary zip_views work") { REQUIRE(nested.size() == 3); }
+
+      THEN("Can iterate with temporary containers")
+      {
+        int count = 0;
+        for (auto it = nested.begin(); it != nested.end(); ++it) { ++count; }
+        REQUIRE(count == 3);
+      }
+
+      THEN("Can dereference and access temporary container elements")
+      {
+        auto it   = nested.begin();
+        auto elem = *it;
+        auto t0   = std::get<0>(elem);
+        auto t1   = std::get<1>(elem);
+        REQUIRE(std::get<0>(t0) == 1);
+        REQUIRE(std::get<1>(t0) == 4);
+        REQUIRE(std::get<0>(t1) == 'a');
+        REQUIRE(std::get<1>(t1) == 'x');
+      }
+    }
+
+    WHEN("Using subscript operator with temporary nested zip_views")
+    {
+      std::vector<int> v1 = {10, 20, 30};
+      std::vector<int> v2 = {40, 50, 60};
+      std::vector<int> v3 = {70, 80, 90};
+
+      auto nested =
+        gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), gst::ranges::views::zip(v2, v3));
+
+      THEN("Subscript operator works with temporary nested zip_views")
+      {
+        auto elem = nested[1];
+        auto t0   = std::get<0>(elem);
+        auto t1   = std::get<1>(elem);
+        REQUIRE(std::get<0>(t0) == 20);
+        REQUIRE(std::get<1>(t0) == 50);
+        REQUIRE(std::get<0>(t1) == 50);
+        REQUIRE(std::get<1>(t1) == 80);
+      }
+
+      THEN("front() and back() work with temporaries")
+      {
+        auto front = nested.front();
+        auto back  = nested.back();
+
+        auto front_t0 = std::get<0>(front);
+        REQUIRE(std::get<0>(front_t0) == 10);
+
+        auto back_t1 = std::get<1>(back);
+        REQUIRE(std::get<1>(back_t1) == 90);
+      }
+    }
+
+    WHEN("Modifying through temporary nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2, 3};
+      std::vector<int> v2 = {4, 5, 6};
+      std::vector<int> v3 = {7, 8, 9};
+
+      auto nested = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+
+      THEN("Can modify underlying containers through temporary zip_view")
+      {
+        auto it           = nested.begin();
+        auto elem         = *it;
+        std::get<1>(elem) = 99;
+        REQUIRE(v3[0] == 99);
+
+        auto nested_tuple         = std::get<0>(elem);
+        std::get<0>(nested_tuple) = 88;
+        REQUIRE(v1[0] == 88);
+      }
+    }
+
+    WHEN("Comparing temporary nested zip_views with std::ranges::zip_view")
+    {
+      std::vector<int> v1 = {1, 2, 3};
+      std::vector<int> v2 = {4, 5, 6};
+      std::vector<int> v3 = {7, 8, 9};
+      std::vector<int> v4 = {10, 11, 12};
+
+      auto gst_nested = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2, v3),
+                                                gst::ranges::views::zip(v2, v3, v4),
+                                                gst::ranges::views::zip(v3, v4, v1));
+      auto std_nested = std::ranges::views::zip(std::ranges::views::zip(v1, v2, v3),
+                                                std::ranges::views::zip(v2, v3, v4),
+                                                std::ranges::views::zip(v3, v4, v1));
+
+      THEN("Temporary nested structures match std behavior")
+      {
+        REQUIRE(gst_nested.size() == std_nested.size());
+        REQUIRE(gst_nested.empty() == std_nested.empty());
+
+        auto gst_it = gst_nested.begin();
+        auto std_it = std_nested.begin();
+
+        int count = 0;
+        while (gst_it != gst_nested.end() && std_it != std_nested.end())
+        {
+          auto gst_elem = *gst_it;
+          auto std_elem = *std_it;
+          REQUIRE((gst_elem == std_elem));
+          ++gst_it;
+          ++std_it;
+          ++count;
+        }
+        REQUIRE(count == 3);
+      }
+    }
+
+    WHEN("Using range-based for loop with temporary nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2, 3};
+      std::vector<int> v2 = {4, 5, 6};
+      std::vector<int> v3 = {7, 8, 9};
+
+      THEN("Can iterate with range-based for on temporary nested zip_views")
+      {
+        auto nested =
+          gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), gst::ranges::views::zip(v2, v3));
+        int count = 0;
+        for (auto elem : nested)
+        {
+          (void)elem;
+          ++count;
+        }
+        REQUIRE(count == 3);
+      }
+
+      THEN("Can modify through range-based for on temporary nested zip_views")
+      {
+        auto nested = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+
+        for (auto&& elem : nested)
+        {
+          auto nested_tuple          = std::get<0>(elem);
+          std::get<0>(nested_tuple) *= 2;
+          std::get<1>(elem)         += 100;
+        }
+
+        REQUIRE(v1 == std::vector<int>{2, 4, 6});
+        REQUIRE(v3 == std::vector<int>{107, 108, 109});
+      }
+    }
+
+    WHEN("Using range-based for loop with stored nested zip_views")
+    {
+      std::vector<int> v1 = {10, 20, 30};
+      std::vector<int> v2 = {40, 50, 60};
+      std::vector<int> v3 = {70, 80, 90};
+      std::vector<int> v4 = {100, 110, 120};
+
+      auto zip1   = gst::ranges::views::zip(v1, v2);
+      auto zip2   = gst::ranges::views::zip(v3, v4);
+      auto nested = gst::ranges::views::zip(zip1, zip2);
+
+      THEN("Can iterate with range-based for on stored nested zip_views")
+      {
+        int count = 0;
+        int sum   = 0;
+        for (auto elem : nested)
+        {
+          auto t0  = std::get<0>(elem);
+          sum     += std::get<0>(t0);
+          ++count;
+        }
+        REQUIRE(count == 3);
+        REQUIRE(sum == 60); // 10 + 20 + 30
+      }
+
+      THEN("Can modify through range-based for on stored nested zip_views")
+      {
+        for (auto&& elem : nested)
+        {
+          auto t0          = std::get<0>(elem);
+          auto t1          = std::get<1>(elem);
+          std::get<0>(t0) += 5;
+          std::get<1>(t1) += 10;
+        }
+
+        REQUIRE(v1 == std::vector<int>{15, 25, 35});
+        REQUIRE(v4 == std::vector<int>{110, 120, 130});
+      }
     }
   }
 }


### PR DESCRIPTION
Replace std::tie with direct tuple construction in subscripts() and
dereference() methods. std::tie requires lvalue references but nested
zip_views return tuple values, causing compilation errors.

Add tests covering:
- Basic nested zip_view operations (empty, single, multiple, mixed)
- Temporary nested zip_views with inline creation
- Range-based for loops with nested structures
- STL algorithms (for_each, transform, find_if, accumulate, etc.)

Add nested zip_view benchmarks