### PR TITLE
Refactor CMake configuration for per-target control

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,10 +76,10 @@ clang-tidy -p build path/to/file.cpp
 
 ### Coverage / sanitizers
 
-- Coverage is enabled for `ZipViewTests` on GCC/Clang via the `CODE_COVERAGE` option (default ON in `tests/CMakeLists.txt`). Disable it if you want a “normal” build:
+- Coverage is disabled by default. Enable it for `ZipViewTests` on GCC/Clang via the `CODE_COVERAGE` option:
 
 ```bash
-cmake -S . -B build -DCODE_COVERAGE=OFF
+cmake -S . -B build -DCODE_COVERAGE=ON
 ```
 
 - If `gcovr` is installed, a `coverage` target may be available:

--- a/.github/scripts/merge_benchmarks.py
+++ b/.github/scripts/merge_benchmarks.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Merge per-arch Google Benchmark JSON artifacts into a single JSON and create a simple markdown summary.
+
+Usage: merge_benchmarks.py --artifacts-dir artifacts --out-dir merged
+"""
+import argparse
+import json
+import os
+import sys
+
+DEFAULT_ARCHES = ["x86_64", "x86_32", "arm64", "arm32"]
+
+
+def load_json_if_exists(path):
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception as e:
+        return {"error": f"failed to parse {path}: {e}"}
+
+
+def load_console_if_exists(path):
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            return f.read()
+    except Exception as e:
+        return f"failed to read {path}: {e}"
+
+
+def create_summary(merged, out_path):
+    lines = []
+    lines.append("## Benchmark Results Summary (All Architectures)\n")
+    for block in merged:
+        arch = block.get("arch")
+        results = block.get("results") or {}
+        lines.append(f"### {arch}\n")
+        benches = results.get("benchmarks") if isinstance(results, dict) else []
+        if benches:
+            lines.append("```text")
+            for b in benches:
+                name = b.get("name")
+                time = b.get("real_time")
+                unit = b.get("time_unit")
+                lines.append(f"{name}: {time} {unit}")
+            lines.append("```\n")
+        else:
+            # Fallback: include a short note and any console snippet if present
+            console = block.get("console")
+            if console:
+                lines.append("No parsed benchmarks; console output follows (first 200 chars):\n")
+                lines.append(console[:200].replace('```', "`` `") + "\n")
+            else:
+                lines.append("No benchmark data found\n")
+    with open(out_path, "w") as f:
+        f.write("\n".join(lines))
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--artifacts-dir", default="artifacts", help="Path where per-arch artifact folders live")
+    p.add_argument("--out-dir", default="merged", help="Path where merged outputs are written")
+    p.add_argument("--arches", default=','.join(DEFAULT_ARCHES), help="Comma-separated list of architectures to look for")
+    args = p.parse_args()
+
+    artifacts_dir = args.artifacts_dir
+    out_dir = args.out_dir
+    arches = [a.strip() for a in args.arches.split(',') if a.strip()]
+
+    os.makedirs(out_dir, exist_ok=True)
+
+    merged = []
+
+    for arch in arches:
+        json_path = os.path.join(artifacts_dir, f"benchmark-results-{arch}", "benchmark_results.json")
+        console_path = os.path.join(artifacts_dir, f"benchmark-results-{arch}", "benchmark_console.txt")
+
+        data = load_json_if_exists(json_path)
+        console = None
+        if data is None:
+            # try to fallback to console
+            console = load_console_if_exists(console_path)
+            if console is not None:
+                entry = {"arch": arch, "results": {"error": "no json, console available"}, "console": console}
+            else:
+                entry = {"arch": arch, "results": None}
+        else:
+            entry = {"arch": arch, "results": data}
+            # still attach console snippet if available (handy for debugging)
+            console = load_console_if_exists(console_path)
+            if console is not None:
+                entry["console"] = console[:1000]
+        merged.append(entry)
+
+    merged_path = os.path.join(out_dir, "benchmark_results_merged.json")
+    with open(merged_path, "w") as f:
+        json.dump(merged, f, indent=2)
+
+    # Create human-readable summary
+    summary_path = os.path.join(out_dir, "benchmark_summary.md")
+    create_summary(merged, summary_path)
+
+    # Print results for logs
+    print("Wrote:", merged_path)
+    print(open(merged_path).read())
+    print("---\nSummary:\n")
+    print(open(summary_path).read())
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,7 +21,7 @@ jobs:
             runner: ubuntu-latest
             build_dir: build
             cmake_flags: ""
-            cxx_compiler: g++
+            cxx_compiler: clang++
             run_prefix: ""
           - arch: x86_32
             runner: ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
             runner: ubuntu-24.04-arm
             build_dir: build-arm
             cmake_flags: ""
-            cxx_compiler: g++
+            cxx_compiler: clang++
             run_prefix: ""
           - arch: arm32
             runner: ubuntu-24.04-arm
@@ -69,8 +69,6 @@ jobs:
       run: >
         cmake -B ${{ github.workspace }}/${{ matrix.build_dir }}
         -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }}
-        -DCMAKE_CXX_STANDARD=23
-        -DCMAKE_CXX_STANDARD_REQUIRED=True
         -DCMAKE_BUILD_TYPE=Release
         ${{ matrix.cmake_flags }}
         -S ${{ github.workspace }}
@@ -81,19 +79,23 @@ jobs:
     - name: Run Benchmarks
       run: |
         cd ${{ github.workspace }}/${{ matrix.build_dir }}
-        ${{ matrix.run_prefix }} ./benchmarks/ZipViewBenchmark --reporter console::out=-::colour-mode=none 2>&1 | tee benchmark_results.txt
+        ${{ matrix.run_prefix }} ./benchmarks/ZipViewBenchmark --benchmark_format=json --benchmark_out=benchmark_results.json 2>&1 | tee benchmark_console.txt
 
     - name: Upload Benchmark Results
       uses: actions/upload-artifact@v4
       with:
         name: benchmark-results-${{ matrix.arch }}
-        path: ${{ github.workspace }}/${{ matrix.build_dir }}/benchmark_results.txt
+        path: |
+          ${{ github.workspace }}/${{ matrix.build_dir }}/benchmark_results.json
+          ${{ github.workspace }}/${{ matrix.build_dir }}/benchmark_console.txt
 
   merge-results:
     needs: benchmark
     if: success()
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4
+
     - name: Download all benchmark artifacts
       uses: actions/download-artifact@v4
       with:
@@ -104,46 +106,20 @@ jobs:
     - name: Merge benchmark results
       run: |
         mkdir -p merged
-        echo "# Combined Benchmark Results" > merged/benchmark_results_merged.txt
-        echo "Generated: $(date -u)" >> merged/benchmark_results_merged.txt
-        echo "" >> merged/benchmark_results_merged.txt
-
-        for arch in x86_64 x86_32 arm64 arm32; do
-          if [ -f "artifacts/benchmark-results-${arch}/benchmark_results.txt" ]; then
-            echo "========================================" >> merged/benchmark_results_merged.txt
-            echo "Architecture: ${arch}" >> merged/benchmark_results_merged.txt
-            echo "========================================" >> merged/benchmark_results_merged.txt
-            cat "artifacts/benchmark-results-${arch}/benchmark_results.txt" >> merged/benchmark_results_merged.txt
-            echo "" >> merged/benchmark_results_merged.txt
-          fi
-        done
-
-        cat merged/benchmark_results_merged.txt
+        python3 ./.github/scripts/merge_benchmarks.py --artifacts-dir artifacts --out-dir merged
+        echo "Merged files:" && ls -l merged || true
 
     - name: Create summary markdown
       run: |
-        cd merged
-        echo "## Benchmark Results Summary (All Architectures)" > benchmark_summary.md
-        echo "" >> benchmark_summary.md
-
-        for arch in x86_64 x86_32 arm64 arm32; do
-          if [ -f "../artifacts/benchmark-results-${arch}/benchmark_results.txt" ]; then
-            echo "### ${arch}" >> benchmark_summary.md
-            echo '```' >> benchmark_summary.md
-            grep -A 5 "benchmark name" "../artifacts/benchmark-results-${arch}/benchmark_results.txt" | head -100 >> benchmark_summary.md || echo "No benchmark data found" >> benchmark_summary.md
-            echo '```' >> benchmark_summary.md
-            echo "" >> benchmark_summary.md
-          fi
-        done
-
-        cat benchmark_summary.md
+        echo "Summary created by merge script:"
+        cat merged/benchmark_summary.md || echo "(no summary file found)"
 
     - name: Upload merged results
       uses: actions/upload-artifact@v4
       with:
         name: benchmark-results-merged
         path: |
-          merged/benchmark_results_merged.txt
+          merged/benchmark_results_merged.json
           merged/benchmark_summary.md
 
     - name: Add to Job Summary
@@ -152,7 +128,7 @@ jobs:
         echo "# Combined Benchmark Results (All Architectures)" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
-        cat merged/benchmark_results_merged.txt >> $GITHUB_STEP_SUMMARY
+        cat merged/benchmark_results_merged.json >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
 
   push-results:
@@ -175,8 +151,8 @@ jobs:
       uses: benchmark-action/github-action-benchmark@v1
       with:
         name: C++ Benchmark
-        tool: 'catch2'
-        output-file-path: artifacts/benchmark_results_merged.txt
+        tool: 'google-benchmark'
+        output-file-path: artifacts/benchmark_results_merged.json
         gh-pages-branch: gh-pages
         benchmark-data-dir-path: dev/bench
         auto-push: true

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -74,8 +74,6 @@ jobs:
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-        -DCMAKE_CXX_STANDARD=11
-        -DCMAKE_CXX_STANDARD_REQUIRED=True
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         ${{ matrix.cmake_flags }}
         -S ${{ github.workspace }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,46 +18,48 @@ jobs:
 
     strategy:
       fail-fast: false
-
-      # Set up a matrix to run the following configurations:
-      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
-      # 2. <Linux x64, Release, latest GCC compiler toolchain on the default runner image, default generator>
-      # 3. <Linux x64, Release, latest Clang compiler toolchain on the default runner image, default generator>
-      # 4. <Linux ARM64, Release, GCC compiler on ARM runner>
-      # 5. <Linux ARM64, Release, Clang compiler on ARM runner>
-      # 6. <Linux ARM32, Release, cross-compiled with GCC on ARM runner>
       matrix:
-        os:
-          - ubuntu-latest
-          - ubuntu-24.04-arm
-          - windows-latest
-        cpp_compiler:
-          - g++
-          - clang++
-          - cl
-        build_type:
-          - Release
-        cmake_flags: [""]
         include:
+          # ubuntu-latest with GCC (coverage build)
+          - os: ubuntu-latest
+            cpp_compiler: g++
+            build_type: Release
+            cmake_flags: "-DCODE_COVERAGE=ON"
+          # ubuntu-latest with GCC (no coverage)
+          - os: ubuntu-latest
+            cpp_compiler: g++
+            build_type: Release
+            cmake_flags: ""
+          # ubuntu-latest with Clang
+          - os: ubuntu-latest
+            cpp_compiler: clang++
+            build_type: Release
+            cmake_flags: ""
+          # ubuntu-24.04-arm with GCC (native ARM64)
+          - os: ubuntu-24.04-arm
+            cpp_compiler: g++
+            build_type: Release
+            cmake_flags: ""
+          # ubuntu-24.04-arm with Clang (native ARM64)
+          - os: ubuntu-24.04-arm
+            cpp_compiler: clang++
+            build_type: Release
+            cmake_flags: ""
+          # ubuntu-24.04-arm with ARM32 cross-compile
           - os: ubuntu-24.04-arm
             cpp_compiler: arm-linux-gnueabihf-g++
             build_type: Release
             cmake_flags: "-DCMAKE_CROSSCOMPILING_EMULATOR=qemu-arm"
-        exclude:
+          # windows-latest with MSVC
           - os: windows-latest
-            cpp_compiler: g++
-          - os: windows-latest
-            cpp_compiler: clang++
-          - os: ubuntu-latest
             cpp_compiler: cl
-          - os: ubuntu-24.04-arm
-            cpp_compiler: cl
+            build_type: Release
+            cmake_flags: ""
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Set reusable strings
-      # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
       id: strings
       shell: bash
       run: |
@@ -71,17 +73,13 @@ jobs:
         sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf qemu-user libc6-armhf-cross libstdc++6-armhf-cross
 
     - name: Install gcovr
-      if: matrix.cpp_compiler == 'g++' && matrix.os == 'ubuntu-latest'
+      if: matrix.cmake_flags == '-DCODE_COVERAGE=ON'
       run: sudo apt-get install -y gcovr
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-        -DCMAKE_CXX_STANDARD=11
-        -DCMAKE_CXX_STANDARD_REQUIRED=True
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         ${{ matrix.cmake_flags }}
         -S ${{ github.workspace }}
@@ -95,11 +93,11 @@ jobs:
         QEMU_LD_PREFIX: ${{ matrix.cpp_compiler == 'arm-linux-gnueabihf-g++' && '/usr/arm-linux-gnueabihf' || '' }}
 
     - name: Generate code coverage
-      if: matrix.cpp_compiler == 'g++' && matrix.os == 'ubuntu-latest'
+      if: matrix.cmake_flags == '-DCODE_COVERAGE=ON'
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }} --target coverage
 
     - name: Publish to codecov
-      if: matrix.cpp_compiler == 'g++' && matrix.os == 'ubuntu-latest'
+      if: matrix.cmake_flags == '-DCODE_COVERAGE=ON'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -108,7 +106,7 @@ jobs:
         files: ${{ steps.strings.outputs.build-output-dir }}/coverage.xml
 
     - name: Upload Coverage Report
-      if: matrix.cpp_compiler == 'g++' && matrix.os == 'ubuntu-latest'
+      if: matrix.cmake_flags == '-DCODE_COVERAGE=ON'
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,30 +7,20 @@ enable_testing()
 include(FetchContent)
 include(CTest)
 
-# Fetch Catch2
-FetchContent_Declare(
-  Catch2
-  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG v3.8.0
-)
-FetchContent_MakeAvailable(Catch2)
-
 # Find clang-tidy and clang-format
 find_program(CLANG_TIDY_EXE NAMES clang-tidy)
 find_program(CLANG_FORMAT_EXE NAMES clang-format)
 
 # Set variables
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-	add_compile_options(-pedantic -Werror -Wall -Wextra -Wconversion -Wshadow -Wunused -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wuseless-cast -Wdouble-promotion)
+	set(PROJECT_COMPILE_OPTIONS -pedantic -Werror -Wall -Wextra -Wconversion -Wshadow -Wunused -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wuseless-cast -Wdouble-promotion)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  add_compile_options(-Werror -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-c++-compat -Wno-padded)
+  set(PROJECT_COMPILE_OPTIONS -Werror -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-c++-compat -Wno-padded)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  add_compile_options(/W4 /WX)
+  set(PROJECT_COMPILE_OPTIONS /W4 /WX)
 endif()
 
 # Include directories
@@ -61,45 +51,4 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     if(ENABLE_SANITIZERS)
         add_compile_options(-fsanitize=address,undefined)
     endif()
-endif()
-
-# Add gcovr target
-if(CODE_COVERAGE)
-  find_program(GCOVR_EXE NAMES gcovr)
-  if(GCOVR_EXE)
-    # Common gcovr args
-    set(GCOVR_FILTER_ARGS --filter ${CMAKE_SOURCE_DIR}/include/ --exclude-throw-branches)
-    set(GCOVR_GCOV_OPTION "")
-
-    # For Clang, prefer using llvm-cov as the gcov wrapper
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-      find_program(LLVM_COV_EXE NAMES llvm-cov)
-      if(LLVM_COV_EXE)
-        set(GCOVR_GCOV_OPTION --gcov-executable "${LLVM_COV_EXE} gcov")
-      else()
-        message(WARNING "llvm-cov not found! Coverage report will not be generated for Clang.")
-        set(SKIP_COVERAGE TRUE)
-      endif()
-    endif()
-
-    if(NOT SKIP_COVERAGE)
-      add_custom_target(
-        coverage-html
-        COMMAND ${GCOVR_EXE} -r ${CMAKE_SOURCE_DIR} ${GCOVR_GCOV_OPTION} ${GCOVR_FILTER_ARGS} --html --html-details -o coverage.html
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        COMMENT "Generating code coverage HTML report with gcovr for include folder only"
-      )
-      add_custom_target(
-        coverage-xml
-        COMMAND ${GCOVR_EXE} -r ${CMAKE_SOURCE_DIR} ${GCOVR_GCOV_OPTION} ${GCOVR_FILTER_ARGS} --xml-pretty -o coverage.xml
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        COMMENT "Generating code coverage XML report with gcovr for include folder only"
-      )
-      add_custom_target(
-        coverage
-        DEPENDS coverage-html coverage-xml
-        COMMENT "Aggregate target to generate all coverage reports"
-      )
-    endif()
-  endif()
 endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,10 +1,38 @@
+# Use C++23 for benchmarks and Google Benchmark
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Fetch Google Benchmark if not already available
+if(NOT TARGET benchmark::benchmark)
+  FetchContent_Declare(
+    benchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG v1.9.1
+  )
+  set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+  set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
+  set(HAVE_STD_REGEX ON CACHE BOOL "" FORCE)
+  set(RUN_HAVE_STD_REGEX 0 CACHE STRING "" FORCE)
+  FetchContent_MakeAvailable(benchmark)
+endif()
+
 file(GLOB_RECURSE ALL_BENCH_SOURCES "${CMAKE_SOURCE_DIR}/benchmarks/*.cpp")
 
 # Add executables
 add_executable(ZipViewBenchmark ${ALL_BENCH_SOURCES})
 
-# Set C++ standard for each target
-set_target_properties(ZipViewBenchmark PROPERTIES CXX_STANDARD 23)
+# Apply project warning flags to our benchmark code, but exclude some that conflict with Google Benchmark
+target_compile_options(ZipViewBenchmark PRIVATE ${PROJECT_COMPILE_OPTIONS})
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  # Disable specific warnings that Google Benchmark triggers
+  target_compile_options(ZipViewBenchmark PRIVATE
+    -Wno-global-constructors
+    -Wno-weak-vtables
+    -Wno-exit-time-destructors
+    -Wno-switch-default
+  )
+endif()
 
 # Link libraries
-target_link_libraries(ZipViewBenchmark PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(ZipViewBenchmark PRIVATE benchmark::benchmark benchmark::benchmark_main)

--- a/benchmarks/algo.cpp
+++ b/benchmarks/algo.cpp
@@ -1,12 +1,4 @@
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#endif
-#include <catch2/benchmark/catch_benchmark.hpp>
-#include <catch2/catch_test_macros.hpp>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include <benchmark/benchmark.h>
 
 #include "zip_view.hpp"
 #include <algorithm>
@@ -14,122 +6,70 @@
 #include <ranges>
 #include <vector>
 
-TEST_CASE("Benchmark ZipView Accumulate", "[algo]")
+static void BM_StdZipWithSort(benchmark::State& state)
 {
-  std::vector<int> v1(1000000);
-  auto             zip_ref = std::ranges::views::zip(v1);
-  auto             zip_sut = gst::ranges::views::zip(v1);
-
-  BENCHMARK("std zip accumulate")
+  for (auto _ : state)
   {
-    return std::accumulate(
-      zip_ref.begin(), zip_ref.end(), 0, [](auto acc, auto t) { return acc + std::get<0>(t); });
-  };
+    state.PauseTiming();
+    std::vector<int>  v1(10000);
+    std::vector<char> v2(10000);
+    std::iota(v1.begin(), v1.end(), 0);
+    std::iota(v2.begin(), v2.end(), 0);
+    auto zip = std::ranges::views::zip(v1, v2);
+    state.ResumeTiming();
 
-  BENCHMARK("gst zip accumulate")
-  {
-    return std::accumulate(
-      zip_sut.begin(), zip_sut.end(), 0, [](auto acc, auto t) { return acc + std::get<0>(t); });
-  };
+    std::ranges::sort(zip,
+                      [](auto const& a, auto const& b) { return std::get<0>(a) > std::get<0>(b); });
+    benchmark::DoNotOptimize(v1.data());
+  }
 }
+BENCHMARK(BM_StdZipWithSort);
 
-TEST_CASE("Benchmark ZipView Transform", "[algo]")
+static void BM_GstZipWithSort(benchmark::State& state)
 {
-  std::vector<int> v1(1000000);
-  std::vector<int> v2(v1.size());
-  auto             zip_ref  = std::ranges::views::zip(v1);
-  auto             zip_sut  = gst::ranges::views::zip(v1);
-  auto const       doubling = [](auto t) { return std::get<0>(t) * 2; };
-
-  BENCHMARK("std zip transform")
+  for (auto _ : state)
   {
-    std::transform(zip_ref.begin(), zip_ref.end(), v2.begin(), doubling);
-    return v2;
-  };
+    state.PauseTiming();
+    std::vector<int>  v1(10000);
+    std::vector<char> v2(10000);
+    std::iota(v1.begin(), v1.end(), 0);
+    std::iota(v2.begin(), v2.end(), 0);
+    auto zip = gst::ranges::views::zip(v1, v2);
+    state.ResumeTiming();
 
-  BENCHMARK("gst zip transform")
-  {
-    std::transform(zip_sut.begin(), zip_sut.end(), v2.begin(), doubling);
-    return v2;
-  };
+    std::ranges::sort(zip,
+                      [](auto const& a, auto const& b) { return std::get<0>(a) > std::get<0>(b); });
+    benchmark::DoNotOptimize(v1.data());
+  }
 }
+BENCHMARK(BM_GstZipWithSort);
 
-TEST_CASE("Benchmark ZipView Sort", "[algo]")
+static void BM_StdZipWithFind(benchmark::State& state)
 {
-  BENCHMARK("std zip + sort")
-  {
-    std::vector<int> v1{5, 2, 8, 1, 9, 3, 7, 4, 6};
-    std::vector<int> v2{50, 20, 80, 10, 90, 30, 70, 40, 60};
-    auto             zip_ref = std::ranges::views::zip(v1, v2);
-
-    // Need to use ranges algorithms or create a temporary container
-    std::vector<std::tuple<int, int>> temp;
-    temp.reserve(v1.size());
-    for (auto t : zip_ref) { temp.push_back(std::make_tuple(std::get<0>(t), std::get<1>(t))); }
-    std::sort(temp.begin(), temp.end());
-    return temp;
-  };
-
-  BENCHMARK("gst zip + sort")
-  {
-    std::vector<int> v1{5, 2, 8, 1, 9, 3, 7, 4, 6};
-    std::vector<int> v2{50, 20, 80, 10, 90, 30, 70, 40, 60};
-    auto             zip_sut = gst::ranges::views::zip(v1, v2);
-    std::sort(zip_sut.begin(),
-              zip_sut.end(),
-              [](auto const& a, auto const& b) { return std::get<0>(a) < std::get<0>(b); });
-    return v1;
-  };
-}
-
-TEST_CASE("Benchmark ZipView Find", "[algo]")
-{
-  std::vector<int> v1(100000);
-  std::vector<int> v2(100000);
-
-  // Fill with values
+  std::vector<int>  v1(100000);
+  std::vector<char> v2(100000);
   std::iota(v1.begin(), v1.end(), 0);
-  std::iota(v2.begin(), v2.end(), 100000);
+  auto zip = std::ranges::views::zip(v1, v2);
 
-  auto zip_ref = std::ranges::views::zip(v1, v2);
-  auto zip_sut = gst::ranges::views::zip(v1, v2);
-
-  BENCHMARK("std zip + find_if")
+  for (auto _ : state)
   {
-    auto it = std::find_if(std::ranges::begin(zip_ref),
-                           std::ranges::end(zip_ref),
-                           [](auto const& t) { return std::get<0>(t) == 75000; });
-    return it != std::ranges::end(zip_ref);
-  };
-
-  BENCHMARK("gst zip + find_if")
-  {
-    auto it = std::find_if(
-      zip_sut.begin(), zip_sut.end(), [](auto const& t) { return std::get<0>(t) == 75000; });
-    return it != zip_sut.end();
-  };
+    auto it = std::ranges::find_if(zip, [](auto const& t) { return std::get<0>(t) == 50000; });
+    benchmark::DoNotOptimize(it);
+  }
 }
+BENCHMARK(BM_StdZipWithFind);
 
-TEST_CASE("Benchmark ZipView Copy", "[algo]")
+static void BM_GstZipWithFind(benchmark::State& state)
 {
-  std::vector<int> v1(100000);
-  std::vector<int> v2(100000);
-  std::vector<int> out1(100000);
-  std::vector<int> out2(100000);
+  std::vector<int>  v1(100000);
+  std::vector<char> v2(100000);
+  std::iota(v1.begin(), v1.end(), 0);
+  auto zip = gst::ranges::views::zip(v1, v2);
 
-  auto zip_ref = std::ranges::views::zip(v1, v2);
-  auto zip_sut = gst::ranges::views::zip(v1, v2);
-  auto zip_out = gst::ranges::views::zip(out1, out2);
-
-  BENCHMARK("std zip + copy")
+  for (auto _ : state)
   {
-    std::copy(std::ranges::begin(zip_ref), std::ranges::end(zip_ref), zip_out.begin());
-    return out1;
-  };
-
-  BENCHMARK("gst zip + copy")
-  {
-    std::copy(zip_sut.begin(), zip_sut.end(), zip_out.begin());
-    return out1;
-  };
+    auto it = std::ranges::find_if(zip, [](auto const& t) { return std::get<0>(t) == 50000; });
+    benchmark::DoNotOptimize(it);
+  }
 }
+BENCHMARK(BM_GstZipWithFind);

--- a/benchmarks/ctor.cpp
+++ b/benchmarks/ctor.cpp
@@ -1,28 +1,61 @@
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#endif
-#include <catch2/benchmark/catch_benchmark.hpp>
-#include <catch2/catch_test_macros.hpp>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include <benchmark/benchmark.h>
 
 #include "zip_view.hpp"
 #include <ranges>
 #include <vector>
 
-TEST_CASE("Benchmark ZipView Constructor", "[ctor]")
+static void BM_StdZipConstruction(benchmark::State& state)
 {
-  BENCHMARK("std zip construct")
-  {
-    std::vector<int> v1(1000000);
-    return std::ranges::views::zip(v1);
-  };
+  std::vector<int>  v1(1000);
+  std::vector<char> v2(1000);
 
-  BENCHMARK("gst zip construct")
+  for (auto _ : state)
   {
-    std::vector<int> v1(1000000);
-    return gst::ranges::views::zip(v1);
-  };
+    auto zip = std::ranges::views::zip(v1, v2);
+    benchmark::DoNotOptimize(zip);
+  }
 }
+BENCHMARK(BM_StdZipConstruction);
+
+static void BM_GstZipConstruction(benchmark::State& state)
+{
+  std::vector<int>  v1(1000);
+  std::vector<char> v2(1000);
+
+  for (auto _ : state)
+  {
+    auto zip = gst::ranges::views::zip(v1, v2);
+    benchmark::DoNotOptimize(zip);
+  }
+}
+BENCHMARK(BM_GstZipConstruction);
+
+static void BM_StdZipConstruction4Containers(benchmark::State& state)
+{
+  std::vector<int>    v1(1000);
+  std::vector<double> v2(1000);
+  std::vector<char>   v3(1000);
+  std::vector<float>  v4(1000);
+
+  for (auto _ : state)
+  {
+    auto zip = std::ranges::views::zip(v1, v2, v3, v4);
+    benchmark::DoNotOptimize(zip);
+  }
+}
+BENCHMARK(BM_StdZipConstruction4Containers);
+
+static void BM_GstZipConstruction4Containers(benchmark::State& state)
+{
+  std::vector<int>    v1(1000);
+  std::vector<double> v2(1000);
+  std::vector<char>   v3(1000);
+  std::vector<float>  v4(1000);
+
+  for (auto _ : state)
+  {
+    auto zip = gst::ranges::views::zip(v1, v2, v3, v4);
+    benchmark::DoNotOptimize(zip);
+  }
+}
+BENCHMARK(BM_GstZipConstruction4Containers);

--- a/benchmarks/iter.cpp
+++ b/benchmarks/iter.cpp
@@ -1,213 +1,65 @@
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#endif
-#include <catch2/benchmark/catch_benchmark.hpp>
-#include <catch2/catch_test_macros.hpp>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include <benchmark/benchmark.h>
 
 #include "zip_view.hpp"
-#include <algorithm>
-#include <list>
-#include <numeric>
 #include <ranges>
 #include <vector>
 
-TEST_CASE("Benchmark ZipView Bidirectional Same Sizes", "[bidirectional][same_sizes]")
+static void BM_StdZipIteratorIncrement(benchmark::State& state)
 {
-  std::list<int> l1(100000);
-  std::list<int> l2(100000);
+  std::vector<int>  v1(100000);
+  std::vector<char> v2(100000);
+  auto              zip_ref = std::ranges::views::zip(v1, v2);
 
-  // Fill with values
-  std::iota(l1.begin(), l1.end(), 0);
-  std::iota(l2.begin(), l2.end(), 100000);
-
-  auto zip_ref = std::ranges::views::zip(l1, l2);
-  auto zip_sut = gst::ranges::views::zip(l1, l2);
-
-  BENCHMARK("std zip bidi same sizes")
+  for (auto _ : state)
   {
-    int sum = 0;
-    for (auto t : zip_ref) { sum += std::get<0>(t) + std::get<1>(t); }
-    return sum;
-  };
-
-  BENCHMARK("gst zip bidi same sizes")
-  {
-    int sum = 0;
-    for (auto t : zip_sut) { sum += std::get<0>(t) + std::get<1>(t); }
-    return sum;
-  };
+    auto it = zip_ref.begin();
+    while (it != zip_ref.end()) { ++it; }
+    benchmark::DoNotOptimize(it);
+  }
 }
+BENCHMARK(BM_StdZipIteratorIncrement);
 
-TEST_CASE("Benchmark ZipView Forward Same Sizes", "[forward][same_sizes]")
+static void BM_GstZipIteratorIncrement(benchmark::State& state)
 {
-  std::vector<int> v1(100000);
-  std::vector<int> v2(100000);
+  std::vector<int>  v1(100000);
+  std::vector<char> v2(100000);
+  auto              zip_sut = gst::ranges::views::zip(v1, v2);
 
-  std::iota(v1.begin(), v1.end(), 0);
-  std::iota(v2.begin(), v2.end(), 100000);
-
-  auto zip_ref = std::ranges::views::zip(v1, v2);
-  auto zip_sut = gst::ranges::views::zip(v1, v2);
-
-  BENCHMARK("std zip fwd same sizes")
+  for (auto _ : state)
   {
-    int  sum = 0;
+    auto it = zip_sut.begin();
+    while (it != zip_sut.end()) { ++it; }
+    benchmark::DoNotOptimize(it);
+  }
+}
+BENCHMARK(BM_GstZipIteratorIncrement);
+
+static void BM_StdZipIteratorRandomAccess(benchmark::State& state)
+{
+  std::vector<int>  v1(100000);
+  std::vector<char> v2(100000);
+  auto              zip_ref = std::ranges::views::zip(v1, v2);
+
+  for (auto _ : state)
+  {
     auto it  = zip_ref.begin();
-    while (it != zip_ref.end())
-    {
-      sum += std::get<0>(*it) + std::get<1>(*it);
-      ++it;
-    }
-    return sum;
-  };
+    auto val = it[50000];
+    benchmark::DoNotOptimize(val);
+  }
+}
+BENCHMARK(BM_StdZipIteratorRandomAccess);
 
-  BENCHMARK("gst zip fwd same sizes")
+static void BM_GstZipIteratorRandomAccess(benchmark::State& state)
+{
+  std::vector<int>  v1(100000);
+  std::vector<char> v2(100000);
+  auto              zip_sut = gst::ranges::views::zip(v1, v2);
+
+  for (auto _ : state)
   {
-    int  sum = 0;
     auto it  = zip_sut.begin();
-    while (it != zip_sut.end())
-    {
-      sum += std::get<0>(*it) + std::get<1>(*it);
-      ++it;
-    }
-    return sum;
-  };
+    auto val = it[50000];
+    benchmark::DoNotOptimize(val);
+  }
 }
-
-TEST_CASE("Benchmark ZipView Reverse Same Sizes", "[reverse][same_sizes]")
-{
-  std::vector<int> v1(100000);
-  std::vector<int> v2(100000);
-
-  std::iota(v1.begin(), v1.end(), 0);
-  std::iota(v2.begin(), v2.end(), 100000);
-
-  auto zip_ref = std::ranges::views::zip(v1, v2);
-  auto zip_sut = gst::ranges::views::zip(v1, v2);
-
-  BENCHMARK("std zip rev same sizes")
-  {
-    int  sum = 0;
-    auto it  = zip_ref.end();
-    while (it != zip_ref.begin())
-    {
-      --it;
-      sum += std::get<0>(*it) + std::get<1>(*it);
-    }
-    return sum;
-  };
-
-  BENCHMARK("gst zip rev same sizes")
-  {
-    int  sum = 0;
-    auto it  = zip_sut.end();
-    while (it != zip_sut.begin())
-    {
-      --it;
-      sum += std::get<0>(*it) + std::get<1>(*it);
-    }
-    return sum;
-  };
-}
-
-TEST_CASE("Benchmark ZipView Bidirectional Different Sizes", "[bidirectional][different_sizes]")
-{
-  std::list<int> l1(100000);
-  std::list<int> l2(100001); // Different size
-
-  std::iota(l1.begin(), l1.end(), 0);
-  std::iota(l2.begin(), l2.end(), 100000);
-
-  auto zip_ref = std::ranges::views::zip(l1, l2);
-  auto zip_sut = gst::ranges::views::zip(l1, l2);
-
-  BENCHMARK("std zip bidi diff sizes")
-  {
-    int sum = 0;
-    for (auto t : zip_ref) { sum += std::get<0>(t) + std::get<1>(t); }
-    return sum;
-  };
-
-  BENCHMARK("gst zip bidi diff sizes")
-  {
-    int sum = 0;
-    for (auto t : zip_sut) { sum += std::get<0>(t) + std::get<1>(t); }
-    return sum;
-  };
-}
-
-TEST_CASE("Benchmark ZipView Forward Different Sizes", "[forward][different_sizes]")
-{
-  std::vector<int> v1(100000);
-  std::vector<int> v2(100001); // Different size
-
-  std::iota(v1.begin(), v1.end(), 0);
-  std::iota(v2.begin(), v2.end(), 100000);
-
-  auto zip_ref = std::ranges::views::zip(v1, v2);
-  auto zip_sut = gst::ranges::views::zip(v1, v2);
-
-  BENCHMARK("std zip fwd diff sizes")
-  {
-    int  sum = 0;
-    auto it  = zip_ref.begin();
-    while (it != zip_ref.end())
-    {
-      sum += std::get<0>(*it) + std::get<1>(*it);
-      ++it;
-    }
-    return sum;
-  };
-
-  BENCHMARK("gst zip fwd diff sizes")
-  {
-    int  sum = 0;
-    auto it  = zip_sut.begin();
-    while (it != zip_sut.end())
-    {
-      sum += std::get<0>(*it) + std::get<1>(*it);
-      ++it;
-    }
-    return sum;
-  };
-}
-
-TEST_CASE("Benchmark ZipView Reverse Different Sizes", "[reverse][different_sizes]")
-{
-  std::vector<int> v1(100000);
-  std::vector<int> v2(100001); // Different size
-
-  std::iota(v1.begin(), v1.end(), 0);
-  std::iota(v2.begin(), v2.end(), 100000);
-
-  auto zip_ref = std::ranges::views::zip(v1, v2);
-  auto zip_sut = gst::ranges::views::zip(v1, v2);
-
-  BENCHMARK("std zip rev diff sizes")
-  {
-    int  sum = 0;
-    auto it  = zip_ref.end();
-    while (it != zip_ref.begin())
-    {
-      --it;
-      sum += std::get<0>(*it) + std::get<1>(*it);
-    }
-    return sum;
-  };
-
-  BENCHMARK("gst zip rev diff sizes")
-  {
-    int  sum = 0;
-    auto it  = zip_sut.end();
-    while (it != zip_sut.begin())
-    {
-      --it;
-      sum += std::get<0>(*it) + std::get<1>(*it);
-    }
-    return sum;
-  };
-}
+BENCHMARK(BM_GstZipIteratorRandomAccess);

--- a/benchmarks/loop.cpp
+++ b/benchmarks/loop.cpp
@@ -1,49 +1,46 @@
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#endif
-#include <catch2/benchmark/catch_benchmark.hpp>
-#include <catch2/catch_test_macros.hpp>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include <benchmark/benchmark.h>
 
 #include "zip_view.hpp"
 #include <ranges>
 #include <vector>
 
-TEST_CASE("Benchmark ZipView Iteration", "[loop]")
+static void BM_StdZipIterate(benchmark::State& state)
 {
   std::vector<int> v1(1000000);
   auto             zip_ref = std::ranges::views::zip(v1);
-  auto             zip_sut = gst::ranges::views::zip(v1);
 
-  BENCHMARK("std zip iterate")
+  for (auto _ : state)
   {
     int sum = 0;
     for (auto t : zip_ref) { sum += std::get<0>(t); }
-    return sum;
-  };
+    benchmark::DoNotOptimize(sum);
+  }
+}
+BENCHMARK(BM_StdZipIterate);
 
-  BENCHMARK("gst zip iterate")
+static void BM_GstZipIterate(benchmark::State& state)
+{
+  std::vector<int> v1(1000000);
+  auto             zip_sut = gst::ranges::views::zip(v1);
+
+  for (auto _ : state)
   {
     int sum = 0;
     for (auto t : zip_sut) { sum += std::get<0>(t); }
-    return sum;
-  };
+    benchmark::DoNotOptimize(sum);
+  }
 }
+BENCHMARK(BM_GstZipIterate);
 
-TEST_CASE("Benchmark ZipView Iteration Multiple Containers", "[loop]")
+static void BM_StdZipIterate4Ranges(benchmark::State& state)
 {
   std::vector<int>    v1(100000);
   std::vector<double> v2(100000);
   std::vector<char>   v3(100000);
   std::vector<float>  v4(100000);
+  auto                zip_ref = std::ranges::views::zip(v1, v2, v3, v4);
 
-  auto zip_ref = std::ranges::views::zip(v1, v2, v3, v4);
-  auto zip_sut = gst::ranges::views::zip(v1, v2, v3, v4);
-
-  BENCHMARK("std zip iterate 4 ranges")
+  for (auto _ : state)
   {
     int sum = 0;
     for (auto t : zip_ref)
@@ -51,10 +48,20 @@ TEST_CASE("Benchmark ZipView Iteration Multiple Containers", "[loop]")
       sum += static_cast<int>(std::get<0>(t)) + static_cast<int>(std::get<1>(t)) +
              static_cast<int>(std::get<2>(t)) + static_cast<int>(std::get<3>(t));
     }
-    return sum;
-  };
+    benchmark::DoNotOptimize(sum);
+  }
+}
+BENCHMARK(BM_StdZipIterate4Ranges);
 
-  BENCHMARK("gst zip iterate 4 ranges")
+static void BM_GstZipIterate4Ranges(benchmark::State& state)
+{
+  std::vector<int>    v1(100000);
+  std::vector<double> v2(100000);
+  std::vector<char>   v3(100000);
+  std::vector<float>  v4(100000);
+  auto                zip_sut = gst::ranges::views::zip(v1, v2, v3, v4);
+
+  for (auto _ : state)
   {
     int sum = 0;
     for (auto t : zip_sut)
@@ -62,6 +69,7 @@ TEST_CASE("Benchmark ZipView Iteration Multiple Containers", "[loop]")
       sum += static_cast<int>(std::get<0>(t)) + static_cast<int>(std::get<1>(t)) +
              static_cast<int>(std::get<2>(t)) + static_cast<int>(std::get<3>(t));
     }
-    return sum;
-  };
+    benchmark::DoNotOptimize(sum);
+  }
 }
+BENCHMARK(BM_GstZipIterate4Ranges);

--- a/benchmarks/temp.cpp
+++ b/benchmarks/temp.cpp
@@ -1,147 +1,32 @@
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#endif
-#include <catch2/benchmark/catch_benchmark.hpp>
-#include <catch2/catch_test_macros.hpp>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include <benchmark/benchmark.h>
 
 #include "zip_view.hpp"
-
-#include <algorithm>
-#include <numeric>
+#include <array>
 #include <ranges>
-#include <string>
-#include <tuple>
 #include <vector>
 
-namespace
+static void BM_StdZipWithTemporaries(benchmark::State& state)
 {
-// Small helper to create a non-trivial temporary.
-// Returning by value ensures we exercise the "in-place temporary" case when used inside
-// views::zip(...).
-std::vector<int> make_iota_vec(std::size_t n, int start)
-{
-  std::vector<int> v(n);
-  std::iota(v.begin(), v.end(), start);
-  return v;
+  for (auto _ : state)
+  {
+    auto zip =
+      std::ranges::views::zip(std::vector<int>{1, 2, 3}, std::array<char, 3>{'a', 'b', 'c'});
+    int sum = 0;
+    for (auto t : zip) { sum += std::get<0>(t); }
+    benchmark::DoNotOptimize(sum);
+  }
 }
-} // namespace
+BENCHMARK(BM_StdZipWithTemporaries);
 
-TEST_CASE("Benchmark ZipView In-place Temporary In Loop", "[temp][loop]")
+static void BM_GstZipWithTemporaries(benchmark::State& state)
 {
-  constexpr std::size_t N = 1'000'000;
-
-  BENCHMARK("std zip loop with temporary")
+  for (auto _ : state)
   {
-    long long sum = 0;
-    for (auto t : std::ranges::views::zip(make_iota_vec(N, 0))) { sum += std::get<0>(t); }
-    return sum;
-  };
-
-  BENCHMARK("gst zip loop with temporary")
-  {
-    long long sum = 0;
-    for (auto t : gst::ranges::views::zip(make_iota_vec(N, 0))) { sum += std::get<0>(t); }
-    return sum;
-  };
+    auto zip =
+      gst::ranges::views::zip(std::vector<int>{1, 2, 3}, std::array<char, 3>{'a', 'b', 'c'});
+    int sum = 0;
+    for (auto t : zip) { sum += std::get<0>(t); }
+    benchmark::DoNotOptimize(sum);
+  }
 }
-
-TEST_CASE("Benchmark ZipView In-place Temporaries Multiple Ranges In Loop", "[temp][loop]")
-{
-  constexpr std::size_t N = 250'000;
-
-  BENCHMARK("std zip loop 2 temporaries")
-  {
-    long long sum = 0;
-    for (auto t : std::ranges::views::zip(make_iota_vec(N, 0), make_iota_vec(N, 1)))
-    {
-      sum += std::get<0>(t) + std::get<1>(t);
-    }
-    return sum;
-  };
-
-  BENCHMARK("gst zip loop 2 temporaries")
-  {
-    long long sum = 0;
-    for (auto t : gst::ranges::views::zip(make_iota_vec(N, 0), make_iota_vec(N, 1)))
-    {
-      sum += std::get<0>(t) + std::get<1>(t);
-    }
-    return sum;
-  };
-}
-
-TEST_CASE("Benchmark ZipView In-place Temporary With std::ranges Algorithms", "[temp][algo]")
-{
-  constexpr std::size_t N = 1'000'000;
-
-  BENCHMARK("std zip + ranges::for_each (temporary)")
-  {
-    long long sum = 0;
-    std::ranges::for_each(std::ranges::views::zip(make_iota_vec(N, 0)),
-                          [&](auto t) { sum += std::get<0>(t); });
-    return sum;
-  };
-
-  BENCHMARK("gst zip + ranges::for_each (temporary)")
-  {
-    long long sum = 0;
-    std::ranges::for_each(gst::ranges::views::zip(make_iota_vec(N, 0)),
-                          [&](auto t) { sum += std::get<0>(t); });
-    return sum;
-  };
-
-  BENCHMARK("std zip + ranges::fold_left (temporary)")
-  {
-    return std::ranges::fold_left(std::ranges::views::zip(make_iota_vec(N, 0)),
-                                  0LL,
-                                  [](long long acc, auto t) { return acc + std::get<0>(t); });
-  };
-
-  BENCHMARK("gst zip + ranges::fold_left (temporary)")
-  {
-    return std::ranges::fold_left(gst::ranges::views::zip(make_iota_vec(N, 0)),
-                                  0LL,
-                                  [](long long acc, auto t) { return acc + std::get<0>(t); });
-  };
-
-  BENCHMARK("std zip + ranges::count_if (temporary)")
-  {
-    return std::ranges::count_if(std::ranges::views::zip(make_iota_vec(N, 0)),
-                                 [](auto t) { return (std::get<0>(t) & 1) == 0; });
-  };
-
-  BENCHMARK("gst zip + ranges::count_if (temporary)")
-  {
-    return std::ranges::count_if(gst::ranges::views::zip(make_iota_vec(N, 0)),
-                                 [](auto t) { return (std::get<0>(t) & 1) == 0; });
-  };
-}
-
-TEST_CASE("Benchmark ZipView Temporary + ranges::copy", "[temp][algo]")
-{
-  constexpr std::size_t N = 500'000;
-
-  BENCHMARK("std zip + ranges::copy (temporary)")
-  {
-    auto             r = std::ranges::views::zip(make_iota_vec(N, 0));
-    std::vector<int> out(N);
-    auto             out_zip = gst::ranges::views::zip(out);
-
-    std::ranges::copy(r.begin(), r.end(), out_zip.begin());
-    return out;
-  };
-
-  BENCHMARK("gst zip + ranges::copy (temporary)")
-  {
-    auto             r = gst::ranges::views::zip(make_iota_vec(N, 0));
-    std::vector<int> out(N);
-    auto             out_zip = gst::ranges::views::zip(out);
-
-    std::ranges::copy(r.begin(), r.end(), out_zip.begin());
-    return out;
-  };
-}
+BENCHMARK(BM_GstZipWithTemporaries);

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,9 +1,9 @@
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 file(GLOB_RECURSE ALL_EXAMPLE_SOURCES "${CMAKE_SOURCE_DIR}/examples/*.cpp")
 
-# Add executables
 add_executable(ZipViewExamples ${ALL_EXAMPLE_SOURCES})
 
-# Set C++ standard for each target
-set_target_properties(ZipViewExamples PROPERTIES CXX_STANDARD 11
-                                                 CXX_STANDARD_REQUIRED YES
-                                                 CXX_EXTENSIONS NO)
+target_compile_options(ZipViewExamples PRIVATE ${PROJECT_COMPILE_OPTIONS})

--- a/include/zip_view.hpp
+++ b/include/zip_view.hpp
@@ -190,8 +190,6 @@ template <typename... Containers>
 class zip_view
 {
 private:
-  static constexpr auto INDICES = detail::make_index_sequence<sizeof...(Containers)>{};
-
   using storage_tuple = std::tuple<detail::view_t<Containers>...>;
 
   template <typename T>
@@ -262,6 +260,8 @@ private:
   }
 
 public:
+  static constexpr auto INDICES = detail::make_index_sequence<sizeof...(Containers)>{};
+
   template <typename IterTuple>
   class basic_iterator
   {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,68 @@
+# Fetch Catch2 if not already available
+if(NOT TARGET Catch2::Catch2WithMain)
+  FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.8.0
+  )
+  FetchContent_MakeAvailable(Catch2)
+endif()
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Code coverage option (disabled by default)
+option(CODE_COVERAGE "Enable code coverage" OFF)
+
+# Add gcovr target
+if(CODE_COVERAGE)
+  find_program(GCOVR_EXE NAMES gcovr)
+  if(GCOVR_EXE)
+    # Common gcovr args
+    set(GCOVR_FILTER_ARGS --filter ${CMAKE_SOURCE_DIR}/include/ --exclude-throw-branches)
+    set(GCOVR_GCOV_OPTION "")
+
+    # For Clang, prefer using llvm-cov as the gcov wrapper
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      find_program(LLVM_COV_EXE NAMES llvm-cov)
+      if(LLVM_COV_EXE)
+        set(GCOVR_GCOV_OPTION --gcov-executable "${LLVM_COV_EXE} gcov")
+      else()
+        message(WARNING "llvm-cov not found! Coverage report will not be generated for Clang.")
+        set(SKIP_COVERAGE TRUE)
+      endif()
+    endif()
+
+    if(NOT SKIP_COVERAGE)
+      add_custom_target(
+        coverage-html
+        COMMAND ${GCOVR_EXE} -r ${CMAKE_SOURCE_DIR} ${GCOVR_GCOV_OPTION} ${GCOVR_FILTER_ARGS} --html --html-details -o coverage.html
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMENT "Generating code coverage HTML report with gcovr for include folder only"
+      )
+      add_custom_target(
+        coverage-xml
+        COMMAND ${GCOVR_EXE} -r ${CMAKE_SOURCE_DIR} ${GCOVR_GCOV_OPTION} ${GCOVR_FILTER_ARGS} --xml-pretty -o coverage.xml
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMENT "Generating code coverage XML report with gcovr for include folder only"
+      )
+      add_custom_target(
+        coverage
+        DEPENDS coverage-html coverage-xml
+        COMMENT "Aggregate target to generate all coverage reports"
+      )
+    endif()
+  endif()
+endif()
+
 file(GLOB_RECURSE ALL_TEST_SOURCES "${CMAKE_SOURCE_DIR}/tests/*.cpp")
 
 # Add executables
 add_executable(ZipViewTests ${ALL_TEST_SOURCES})
 
-# Set C++ standard for each target
-set_target_properties(ZipViewTests PROPERTIES CXX_STANDARD 23)
+# Compile options
+target_compile_options(ZipViewTests PRIVATE ${PROJECT_COMPILE_OPTIONS})
 
 # Link libraries
 target_link_libraries(ZipViewTests PRIVATE Catch2::Catch2WithMain)
@@ -13,10 +71,7 @@ target_link_libraries(ZipViewTests PRIVATE Catch2::Catch2WithMain)
 add_test(NAME ZipViewTests COMMAND ZipViewTests)
 
 # Add coverage flags only for ZipViewTests
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  option(CODE_COVERAGE "Enable coverage reporting" ON)
-  if(CODE_COVERAGE)
-    target_compile_options(ZipViewTests PRIVATE --coverage -O0 -g)
-    target_link_options(ZipViewTests PRIVATE --coverage)
-  endif()
+if(CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_compile_options(ZipViewTests PRIVATE --coverage -O0 -g)
+  target_link_options(ZipViewTests PRIVATE --coverage)
 endif()

--- a/tests/algo.cpp
+++ b/tests/algo.cpp
@@ -12,10 +12,8 @@
 
 #include <algorithm>
 #include <array>
-#include <functional>
 #include <list>
 #include <numeric>
-#include <set>
 #include <string>
 #include <vector>
 
@@ -1106,7 +1104,7 @@ SCENARIO("std::partition_point works on partitioned zip_view", "[algorithms][par
   }
 }
 
-SCENARIO("std::sort works on random access zip_view", "[algorithms]")
+SCENARIO("sort works on random access zip_view", "[algorithms]")
 {
   GIVEN("Two vectors where first should be sorted and second follows")
   {
@@ -1116,9 +1114,7 @@ SCENARIO("std::sort works on random access zip_view", "[algorithms]")
     WHEN("we sort the zip_view by the key")
     {
       auto zipped = gst::ranges::views::zip(keys, values);
-      std::sort(zipped.begin(),
-                zipped.end(),
-                [](auto const& a, auto const& b) { return std::get<0>(a) < std::get<0>(b); });
+      std::ranges::sort(zipped, std::less<>(), [](auto const& t) { return std::get<0>(t); });
 
       THEN("both containers are sorted according to the keys")
       {
@@ -1137,9 +1133,7 @@ SCENARIO("std::sort works on random access zip_view", "[algorithms]")
     WHEN("we sort by key")
     {
       auto zipped = gst::ranges::views::zip(keys, names, pairs);
-      std::sort(zipped.begin(),
-                zipped.end(),
-                [](auto const& a, auto const& b) { return std::get<0>(a) < std::get<0>(b); });
+      std::ranges::sort(zipped, std::less<>(), [](auto const& t) { return std::get<0>(t); });
 
       THEN("all three containers are sorted consistently")
       {
@@ -1192,10 +1186,7 @@ SCENARIO("std::stable_sort works on random access zip_view", "[algorithms][sort]
     WHEN("we stable sort by the first element")
     {
       auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      std::stable_sort(zipped.begin(),
-                       zipped.end(),
-                       [](auto const& a, auto const& b)
-                       { return std::get<0>(a) < std::get<0>(b); });
+      std::ranges::stable_sort(zipped, std::less<>(), [](auto const& t) { return std::get<0>(t); });
 
       THEN("equal elements maintain their relative order")
       {

--- a/tests/algo.cpp
+++ b/tests/algo.cpp
@@ -12,8 +12,8 @@
 
 #include <algorithm>
 #include <array>
+#include <functional>
 #include <list>
-#include <numeric>
 #include <string>
 #include <vector>
 
@@ -29,11 +29,9 @@ SCENARIO("std::adjacent_find works on zip_view", "[algorithms][find]")
 
     WHEN("we search for adjacent elements with same first component")
     {
-      auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      auto it     = std::adjacent_find(zipped.begin(),
-                                   zipped.end(),
-                                   [](auto const& a, auto const& b)
-                                   { return std::get<0>(a) == std::get<0>(b); });
+      auto zipped   = gst::ranges::views::zip(v1, v2, v3);
+      auto eq_first = [](auto const& a, auto const& b) { return std::get<0>(a) == std::get<0>(b); };
+      auto it       = std::ranges::adjacent_find(zipped, eq_first);
 
       THEN("we find the first adjacent pair")
       {
@@ -54,26 +52,26 @@ SCENARIO("std::all_of, std::any_of, std::none_of work on zip_view", "[algorithms
     std::vector<int>  v2{1, 1, 1, 1};
     std::vector<char> v3{'a', 'b', 'c', 'd'};
 
-    auto zipped = gst::ranges::views::zip(v1, v2, v3);
+    auto zipped        = gst::ranges::views::zip(v1, v2, v3);
+    auto is_even_first = [](auto const& t) { return std::get<0>(t) % 2 == 0; };
+    auto first_gt_6    = [](auto const& t) { return std::get<0>(t) > 6; };
+    auto first_gt_10   = [](auto const& t) { return std::get<0>(t) > 10; };
 
     THEN("all_of returns true when all elements satisfy the predicate")
     {
-      bool result = std::all_of(
-        zipped.begin(), zipped.end(), [](auto const& t) { return std::get<0>(t) % 2 == 0; });
+      bool result = std::ranges::all_of(zipped, is_even_first);
       REQUIRE(result == true);
     }
 
     THEN("any_of returns true when at least one element satisfies the predicate")
     {
-      bool result =
-        std::any_of(zipped.begin(), zipped.end(), [](auto const& t) { return std::get<0>(t) > 6; });
+      bool result = std::any_of(zipped.begin(), zipped.end(), first_gt_6);
       REQUIRE(result == true);
     }
 
     THEN("none_of returns true when no elements satisfy the predicate")
     {
-      bool result = std::none_of(
-        zipped.begin(), zipped.end(), [](auto const& t) { return std::get<0>(t) > 10; });
+      bool result = std::none_of(zipped.begin(), zipped.end(), first_gt_10);
       REQUIRE(result == true);
     }
   }
@@ -87,25 +85,19 @@ SCENARIO("std::binary_search works on sorted zip_view", "[algorithms][binary_sea
     std::vector<double> v2{1.1, 2.2, 3.3, 4.4, 5.5};
     std::vector<char>   v3{'a', 'b', 'c', 'd', 'e'};
 
-    auto zipped = gst::ranges::views::zip(v1, v2, v3);
+    auto zipped       = gst::ranges::views::zip(v1, v2, v3);
+    auto cmp_by_first = [](auto const& a, auto const& b)
+    { return std::get<0>(a) < std::get<0>(b); };
 
     THEN("binary_search finds existing elements")
     {
-      bool found = std::binary_search(zipped.begin(),
-                                      zipped.end(),
-                                      std::make_tuple(3, 0.0, '\0'),
-                                      [](auto const& a, auto const& b)
-                                      { return std::get<0>(a) < std::get<0>(b); });
+      bool found = std::ranges::binary_search(zipped, std::make_tuple(3, 0.0, '\0'), cmp_by_first);
       REQUIRE(found == true);
     }
 
     THEN("binary_search doesn't find non-existing elements")
     {
-      bool found = std::binary_search(zipped.begin(),
-                                      zipped.end(),
-                                      std::make_tuple(6, 0.0, '\0'),
-                                      [](auto const& a, auto const& b)
-                                      { return std::get<0>(a) < std::get<0>(b); });
+      bool found = std::ranges::binary_search(zipped, std::make_tuple(6, 0.0, '\0'), cmp_by_first);
       REQUIRE(found == false);
     }
   }
@@ -125,20 +117,22 @@ SCENARIO("std::copy_if works with zip_view", "[algorithms][copy]")
       std::vector<double> dest_v2(3);
       std::vector<char>   dest_v3(3);
 
-      auto zipped      = gst::ranges::views::zip(v1, v2, v3);
-      auto dest_zipped = gst::ranges::views::zip(dest_v1, dest_v2, dest_v3);
+      auto is_even_src        = [](auto const& t) { return std::get<0>(t) % 2 == 0; };
+      auto src_zip            = gst::ranges::views::zip(v1, v2, v3);
+      auto dst_zip            = gst::ranges::views::zip(dest_v1, dest_v2, dest_v3);
+      auto [src_end, dst_end] = std::ranges::copy_if(src_zip, dst_zip.begin(), is_even_src);
 
-      auto dest_end = std::copy_if(zipped.begin(),
-                                   zipped.end(),
-                                   dest_zipped.begin(),
-                                   [](auto const& t) { return std::get<0>(t) % 2 == 0; });
+      THEN("the correct number of elements are copied")
+      {
+        REQUIRE(src_end == src_zip.end());
+        REQUIRE(dst_end == dst_zip.end());
+      }
 
       THEN("only tuples with even v1 values are copied")
       {
         REQUIRE(dest_v1 == std::vector<int>{2, 4, 6});
         REQUIRE(dest_v2 == std::vector<double>{2.2, 4.4, 6.6});
         REQUIRE(dest_v3 == std::vector<char>{'b', 'd', 'f'});
-        REQUIRE(std::distance(dest_zipped.begin(), dest_end) == 3);
       }
     }
   }
@@ -161,7 +155,7 @@ SCENARIO("std::equal works with zip_view", "[algorithms][equal]")
     {
       auto zip_a  = gst::ranges::views::zip(v1a, v2a);
       auto zip_b  = gst::ranges::views::zip(v1b, v2b);
-      bool result = std::equal(zip_a.begin(), zip_a.end(), zip_b.begin());
+      bool result = std::ranges::equal(zip_a, zip_b);
       REQUIRE(result == true);
     }
 
@@ -169,7 +163,7 @@ SCENARIO("std::equal works with zip_view", "[algorithms][equal]")
     {
       auto zip_a  = gst::ranges::views::zip(v1a, v2a);
       auto zip_c  = gst::ranges::views::zip(v1c, v2c);
-      bool result = std::equal(zip_a.begin(), zip_a.end(), zip_c.begin());
+      bool result = std::ranges::equal(zip_a, zip_c);
       REQUIRE(result == false);
     }
   }
@@ -186,7 +180,7 @@ SCENARIO("std::find works on zip_view", "[algorithms][find]")
     WHEN("we search for a specific tuple")
     {
       auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      auto it     = std::find(zipped.begin(), zipped.end(), std::make_tuple(3, 3.3, 'c'));
+      auto it     = std::ranges::find(zipped, std::make_tuple(3, 3.3, 'c'));
 
       THEN("we find the tuple")
       {
@@ -209,9 +203,9 @@ SCENARIO("std::find_if works on zip_view", "[algorithms][find]")
 
     WHEN("we search for an element where v1 is even")
     {
-      auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      auto it     = std::find_if(
-        zipped.begin(), zipped.end(), [](auto const& t) { return std::get<0>(t) % 2 == 0; });
+      auto is_even = [](auto const& t) { return std::get<0>(t) % 2 == 0; };
+      auto zipped  = gst::ranges::views::zip(v1, v2, v3);
+      auto it      = std::ranges::find_if(zipped, is_even);
 
       THEN("we find the first even element")
       {
@@ -234,9 +228,9 @@ SCENARIO("std::find_if_not works on zip_view", "[algorithms][find]")
 
     WHEN("we search for the first element that is not even")
     {
-      auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      auto it     = std::find_if_not(
-        zipped.begin(), zipped.end(), [](auto const& t) { return std::get<0>(t) % 2 == 0; });
+      auto is_even = [](auto const& t) { return std::get<0>(t) % 2 == 0; };
+      auto zipped  = gst::ranges::views::zip(v1, v2, v3);
+      auto it      = std::ranges::find_if_not(zipped, is_even);
 
       THEN("we find the first odd element")
       {
@@ -259,23 +253,20 @@ SCENARIO("std::is_sorted works on zip_view", "[algorithms][sorted]")
     std::vector<int>    unsorted_v1{3, 1, 4, 2, 5};
     std::vector<double> unsorted_v2{3.3, 1.1, 4.4, 2.2, 5.5};
 
+    auto cmp_by_first = [](auto const& a, auto const& b)
+    { return std::get<0>(a) < std::get<0>(b); };
+
     THEN("is_sorted returns true for sorted zip_view")
     {
       auto sorted_zip = gst::ranges::views::zip(sorted_v1, sorted_v2);
-      bool result     = std::is_sorted(sorted_zip.begin(),
-                                   sorted_zip.end(),
-                                   [](auto const& a, auto const& b)
-                                   { return std::get<0>(a) < std::get<0>(b); });
+      bool result     = std::ranges::is_sorted(sorted_zip, cmp_by_first);
       REQUIRE(result == true);
     }
 
     THEN("is_sorted returns false for unsorted zip_view")
     {
       auto unsorted_zip = gst::ranges::views::zip(unsorted_v1, unsorted_v2);
-      bool result       = std::is_sorted(unsorted_zip.begin(),
-                                   unsorted_zip.end(),
-                                   [](auto const& a, auto const& b)
-                                   { return std::get<0>(a) < std::get<0>(b); });
+      bool result       = std::ranges::is_sorted(unsorted_zip, cmp_by_first);
       REQUIRE(result == false);
     }
   }
@@ -296,8 +287,7 @@ SCENARIO("std::lexicographical_compare works with zip_view", "[algorithms][compa
       auto zip_a = gst::ranges::views::zip(v1a, v2a);
       auto zip_b = gst::ranges::views::zip(v1b, v2b);
 
-      bool result =
-        std::lexicographical_compare(zip_a.begin(), zip_a.end(), zip_b.begin(), zip_b.end());
+      bool result = std::ranges::lexicographical_compare(zip_a, zip_b);
 
       THEN("the first sequence is less than the second") { REQUIRE(result == true); }
     }
@@ -316,21 +306,14 @@ SCENARIO("std::mismatch works with zip_view", "[algorithms][mismatch]")
 
     WHEN("we find the first mismatch")
     {
-      auto zip_a  = gst::ranges::views::zip(v1a, v2a);
-      auto zip_b  = gst::ranges::views::zip(v1b, v2b);
-      auto result = std::mismatch(zip_a.begin(),
-                                  zip_a.end(),
-                                  zip_b.begin(),
-                                  [](auto const& a, auto const& b) {
-                                    return (std::get<0>(a) == std::get<0>(b)) &&
-                                           (std::get<1>(a) == std::get<1>(b));
-                                  });
+      auto zip_a              = gst::ranges::views::zip(v1a, v2a);
+      auto zip_b              = gst::ranges::views::zip(v1b, v2b);
+      auto [first_a, first_b] = std::ranges::mismatch(zip_a, zip_b, std::equal_to<>{});
 
       THEN("we find the mismatch at position 2")
       {
-        REQUIRE(result.first != zip_a.end());
-        REQUIRE(std::get<0>(*result.first) == 3);
-        REQUIRE(std::get<0>(*result.second) == 9);
+        REQUIRE(std::get<0>(*first_a) == 3);
+        REQUIRE(std::get<0>(*first_b) == 9);
       }
     }
   }
@@ -347,8 +330,7 @@ SCENARIO("std::replace works on zip_view", "[algorithms][replace]")
     WHEN("we replace specific tuples")
     {
       auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      std::replace(
-        zipped.begin(), zipped.end(), std::make_tuple(2, 2.2, 'b'), std::make_tuple(9, 9.9, 'z'));
+      std::ranges::replace(zipped, std::make_tuple(2, 2.2, 'b'), std::make_tuple(9, 9.9, 'z'));
 
       THEN("the matching tuple is replaced")
       {
@@ -370,12 +352,12 @@ SCENARIO("std::replace_if works on zip_view", "[algorithms][replace]")
 
     WHEN("we replace elements where v1 is even")
     {
-      auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      std::replace_if(
-        zipped.begin(),
-        zipped.end(),
-        [](auto const& t) { return std::get<0>(t) % 2 == 0; },
-        std::make_tuple(0, 0.0, 'X'));
+      auto const is_even_first = [](auto const& t) { return std::get<0>(t) % 2 == 0; };
+      auto const replacement   = std::make_tuple(0, 0.0, 'X');
+      auto       zipped        = gst::ranges::views::zip(v1, v2, v3);
+      auto       itr           = std::ranges::replace_if(zipped, is_even_first, replacement);
+
+      THEN("the returned iterator points to the end of the range") { REQUIRE(itr == zipped.end()); }
 
       THEN("tuples with even v1 values are replaced")
       {
@@ -398,7 +380,9 @@ SCENARIO("std::reverse works on random access zip_view", "[algorithms][reverse]"
     WHEN("we reverse the zip_view")
     {
       auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      std::reverse(zipped.begin(), zipped.end());
+      auto itr    = std::ranges::reverse(zipped);
+
+      THEN("the returned iterator points to the end of the range") { REQUIRE(itr == zipped.end()); }
 
       THEN("all containers are reversed")
       {
@@ -424,10 +408,15 @@ SCENARIO("std::reverse_copy works on zip_view", "[algorithms][reverse]")
       std::vector<double> dest_v2(5);
       std::vector<char>   dest_v3(5);
 
-      auto zipped      = gst::ranges::views::zip(v1, v2, v3);
-      auto dest_zipped = gst::ranges::views::zip(dest_v1, dest_v2, dest_v3);
+      auto src_zip            = gst::ranges::views::zip(v1, v2, v3);
+      auto dst_zip            = gst::ranges::views::zip(dest_v1, dest_v2, dest_v3);
+      auto [src_end, dst_end] = std::ranges::reverse_copy(src_zip, dst_zip.begin());
 
-      std::reverse_copy(zipped.begin(), zipped.end(), dest_zipped.begin());
+      THEN("the returned iterator points to the end of the destination range")
+      {
+        REQUIRE(src_end == src_zip.end());
+        REQUIRE(dst_end == dst_zip.end());
+      }
 
       THEN("destination contains reversed elements")
       {
@@ -449,8 +438,14 @@ SCENARIO("std::rotate works on zip_view", "[algorithms][rotate]")
 
     WHEN("we rotate by 2 positions")
     {
-      auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      std::rotate(zipped.begin(), zipped.begin() + 2, zipped.end());
+      auto zipped            = gst::ranges::views::zip(v1, v2, v3);
+      auto [new_first, last] = std::ranges::rotate(zipped, zipped.begin() + 2);
+
+      THEN("the returned iterators point to the new first and last positions")
+      {
+        REQUIRE(new_first == std::ranges::prev(zipped.end(), 2));
+        REQUIRE(last == zipped.end());
+      }
 
       THEN("all containers are rotated together")
       {
@@ -472,20 +467,26 @@ SCENARIO("std::rotate_copy works on zip_view", "[algorithms][rotate]")
 
     WHEN("we rotate and copy")
     {
-      std::vector<int>    dest_v1(5);
-      std::vector<double> dest_v2(5);
-      std::vector<char>   dest_v3(5);
+      std::array<int, 5>    dest_v1;
+      std::array<double, 5> dest_v2;
+      std::array<short, 5>  dest_v3;
 
-      auto zipped      = gst::ranges::views::zip(v1, v2, v3);
-      auto dest_zipped = gst::ranges::views::zip(dest_v1, dest_v2, dest_v3);
+      auto src_zip            = gst::ranges::views::zip(v1, v2, v3);
+      auto dst_zip            = gst::ranges::views::zip(dest_v1, dest_v2, dest_v3);
+      auto itr_mid            = std::next(src_zip.begin(), 2);
+      auto [src_end, dst_end] = std::ranges::rotate_copy(src_zip, itr_mid, dst_zip.begin());
 
-      std::rotate_copy(zipped.begin(), zipped.begin() + 2, zipped.end(), dest_zipped.begin());
+      THEN("the returned iterators point to the end of the source and destination ranges")
+      {
+        REQUIRE(src_end == src_zip.end());
+        REQUIRE(dst_end == dst_zip.end());
+      }
 
       THEN("destination contains rotated elements")
       {
-        REQUIRE(dest_v1 == std::vector<int>{3, 4, 5, 1, 2});
-        REQUIRE(dest_v2 == std::vector<double>{3.3, 4.4, 5.5, 1.1, 2.2});
-        REQUIRE(dest_v3 == std::vector<char>{'c', 'd', 'e', 'a', 'b'});
+        REQUIRE((dest_v1 == std::array<int, 5>{3, 4, 5, 1, 2}));
+        REQUIRE((dest_v2 == std::array<double, 5>{3.3, 4.4, 5.5, 1.1, 2.2}));
+        REQUIRE((dest_v3 == std::array<short, 5>{'c', 'd', 'e', 'a', 'b'}));
       }
     }
   }
@@ -505,15 +506,18 @@ SCENARIO("std::search works on zip_view", "[algorithms][search]")
     {
       auto zipped         = gst::ranges::views::zip(v1, v2);
       auto pattern_zipped = gst::ranges::views::zip(pattern_v1, pattern_v2);
+      auto [first, last]  = std::ranges::search(zipped, pattern_zipped);
 
-      auto it =
-        std::search(zipped.begin(), zipped.end(), pattern_zipped.begin(), pattern_zipped.end());
+      THEN("the returned iterators point to the start and end of the found subsequence")
+      {
+        REQUIRE(first == zipped.begin() + 2);
+        REQUIRE(last == zipped.begin() + 4);
+      }
 
       THEN("we find the subsequence")
       {
-        REQUIRE(it != zipped.end());
-        REQUIRE(std::get<0>(*it) == 3);
-        REQUIRE(std::get<1>(*it) == 'c');
+        REQUIRE(std::get<0>(*first) == 3);
+        REQUIRE(std::get<1>(*first) == 'c');
       }
     }
   }
@@ -528,14 +532,19 @@ SCENARIO("std::search_n works on zip_view", "[algorithms][search]")
 
     WHEN("we search for 3 consecutive occurrences")
     {
-      auto zipped = gst::ranges::views::zip(v1, v2);
-      auto it     = std::search_n(zipped.begin(), zipped.end(), 3, std::make_tuple(5, 'c'));
+      auto zipped        = gst::ranges::views::zip(v1, v2);
+      auto [first, last] = std::ranges::search_n(zipped, 3, std::make_tuple(5, 'c'));
+
+      THEN("the returned iterators point to the start and end of the found sequence")
+      {
+        REQUIRE(first == zipped.begin() + 2);
+        REQUIRE(last == zipped.begin() + 5);
+      }
 
       THEN("we find the sequence")
       {
-        REQUIRE(it != zipped.end());
-        REQUIRE(std::get<0>(*it) == 5);
-        REQUIRE(std::get<1>(*it) == 'c');
+        REQUIRE(std::get<0>(*first) == 5);
+        REQUIRE(std::get<1>(*first) == 'c');
       }
     }
   }
@@ -553,10 +562,15 @@ SCENARIO("std::swap_ranges works on zip_view", "[algorithms][swap]")
 
     WHEN("we swap the ranges")
     {
-      auto zip_a = gst::ranges::views::zip(v1a, v2a);
-      auto zip_b = gst::ranges::views::zip(v1b, v2b);
+      auto zip_a          = gst::ranges::views::zip(v1a, v2a);
+      auto zip_b          = gst::ranges::views::zip(v1b, v2b);
+      auto [end_a, end_b] = std::ranges::swap_ranges(zip_a, zip_b);
 
-      std::swap_ranges(zip_a.begin(), zip_a.end(), zip_b.begin());
+      THEN("the iterators point to the end of the ranges")
+      {
+        REQUIRE(end_a == zip_a.end());
+        REQUIRE(end_b == zip_b.end());
+      }
 
       THEN("the ranges are swapped")
       {
@@ -577,17 +591,18 @@ SCENARIO("zip_view with conditional accumulate based on boolean predicate", "[al
     std::vector<double> v2{4.1, 5.2, 6.3, 7.4};
     std::list<char>     v3{'a', 'b', 'c', 'd', 'e'};
 
-    THEN("we can conditionally accumulate based on the boolean first element")
+    WHEN("we conditionally accumulate based on the boolean first element")
     {
-      auto zip = gst::ranges::views::zip(v1, v2, v3);
-      auto sum =
-        std::accumulate(zip.begin(),
-                        zip.end(),
-                        0.0,
-                        [](auto acc, auto t)
-                        { return acc + (std::get<0>(t) ? std::get<1>(t) + std::get<2>(t) : 0); });
+      auto cond_accum = [](auto acc, auto const& t)
+      { return acc + (std::get<0>(t) ? std::get<1>(t) + std::get<2>(t) : 0); };
 
-      REQUIRE(sum == Catch::Approx(4.1F + 'a' + 6.3F + 'c'));
+      auto zip = gst::ranges::views::zip(v1, v2, v3);
+      auto sum = std::ranges::fold_left(zip, 0.0, cond_accum);
+
+      THEN("the sum is correct based on the predicate")
+      {
+        REQUIRE(sum == Catch::Approx(4.1F + 'a' + 6.3F + 'c'));
+      }
     }
   }
 }
@@ -600,12 +615,21 @@ SCENARIO("zip_view zips three containers and applies for_each", "[algorithms]")
     std::vector<float> v2{4.1F, 5.2F, 6.3F, 7.4F};
     std::list<char>    v3{'a', 'b', 'c', 'd', 'e'};
 
-    THEN("we can zip them and apply for_each to modify elements")
+    WHEN("we apply for_each to double the first element of each tuple")
     {
-      auto zip = gst::ranges::views::zip(v1, v2, v3);
-      std::for_each(zip.begin(), zip.end(), [](auto&& t) { std::get<0>(t) *= 2; });
+      auto double_first = [](auto&& t) { std::get<0>(t) *= 2; };
+      auto zip          = gst::ranges::views::zip(v1, v2, v3);
+      auto [zip_end, _] = std::ranges::for_each(zip, double_first);
 
-      REQUIRE(v1 == std::array<int, 3>{2, 4, 6});
+      THEN("the returned iterator points to the end of the range")
+      {
+        REQUIRE(zip_end == zip.end());
+      }
+
+      THEN("the first elements are doubled while others remain unchanged")
+      {
+        REQUIRE(v1 == std::array<int, 3>{2, 4, 6});
+      }
     }
   }
 }
@@ -618,13 +642,13 @@ SCENARIO("zip_view zips three containers and counts elements with count_if", "[a
     std::vector<float> v2{4.1F, 5.2F, 6.3F, 7.4F};
     std::list<char>    v3{'a', 'b', 'c', 'd', 'e'};
 
-    THEN("we can count elements in the zipped view with count_if")
+    WHEN("we count elements in the zipped view with count_if")
     {
-      auto zip   = gst::ranges::views::zip(v1, v2, v3);
-      auto count = std::count_if(
-        zip.begin(), zip.end(), [](auto const& t) { return std::get<0>(t) % 2 == 0; });
+      auto is_even_first = [](auto const& t) { return std::get<0>(t) % 2 == 0; };
+      auto zip           = gst::ranges::views::zip(v1, v2, v3);
+      auto count         = std::ranges::count_if(zip, is_even_first);
 
-      REQUIRE(count == 1);
+      THEN("the count is correct") { REQUIRE(count == 1); }
     }
   }
 }
@@ -637,12 +661,17 @@ SCENARIO("zip_view zips three containers and fills", "[algorithms]")
     std::vector<float> v2{4.1F, 5.2F, 6.3F, 7.4F};
     std::list<char>    v3{'a', 'b', 'c', 'd', 'e'};
 
-    THEN("we can fill the zipped view")
+    WHEN("we fill the zipped view")
     {
       auto zip = gst::ranges::views::zip(v1, v2, v3);
-      std::fill(zip.begin(), zip.end(), std::make_tuple(0, 0.0F, 'z'));
+      auto end = std::ranges::fill(zip, std::make_tuple(0, 0.0F, 'z'));
 
-      REQUIRE(v1 == std::array<int, 3>{0, 0, 0});
+      THEN("the returned iterator points to the end of the range") { REQUIRE(end == zip.end()); }
+
+      THEN("the containers are filled with the specified values")
+      {
+        REQUIRE(v1 == std::array<int, 3>{0, 0, 0});
+      }
     }
   }
 }
@@ -655,14 +684,18 @@ SCENARIO("zip_view zips three containers and fills with a generator", "[algorith
     std::vector<float> v2{0.0F, 0.0F, 0.0F, 0.0F};
     std::list<char>    v3{' ', ' ', ' ', ' ', ' '};
 
-    THEN("we can fill the zipped view with a generator")
+    WHEN("we fill the zipped view with a generator")
     {
-      auto zip       = gst::ranges::views::zip(v1, v2, v3);
       auto generator = [n = 1]() mutable { return std::make_tuple(n++, 0.0F, ' '); };
+      auto zip       = gst::ranges::views::zip(v1, v2, v3);
+      auto end       = std::ranges::generate(zip, generator);
 
-      std::generate(zip.begin(), zip.end(), generator);
+      THEN("the returned iterator points to the end of the range") { REQUIRE(end == zip.end()); }
 
-      REQUIRE(v1 == std::array<int, 3>{1, 2, 3});
+      THEN("the containers are filled with generated values")
+      {
+        REQUIRE(v1 == std::array<int, 3>{1, 2, 3});
+      }
     }
   }
 }
@@ -675,13 +708,24 @@ SCENARIO("zip_view zips three containers and removes elements with remove_if", "
     std::vector<float>  v2{4.1F, 5.2F, 6.3F, 7.4F};
     std::list<char>     v3{'a', 'b', 'c', 'd', 'e'};
 
-    THEN("we can remove elements from the zipped view with remove_if")
+    WHEN("we remove elements from the zipped view based on a predicate")
     {
-      auto zip = gst::ranges::views::zip(v1, v2, v3);
-      auto new_end =
-        std::remove_if(zip.begin(), zip.end(), [](auto const&& t) { return std::get<0>(t); });
+      auto zip           = gst::ranges::views::zip(v1, v2, v3);
+      auto first_is_true = [](auto const& t) { return std::get<0>(t); };
+      auto [ret, last]   = std::ranges::remove_if(zip, first_is_true);
 
-      REQUIRE(new_end == std::next(zip.begin(), 2));
+      THEN("the returned iterator points to the new end of the range")
+      {
+        REQUIRE(ret == std::ranges::next(zip.begin(), 2));
+        REQUIRE(last == zip.end());
+      }
+
+      THEN("the elements with true in the first container are removed")
+      {
+        REQUIRE(v1 == std::array<bool, 3>{false, false, false});
+        REQUIRE(v2 == std::vector<float>{4.1F, 6.3F, 6.3F, 7.4F});
+        REQUIRE(v3 == std::list<char>{'a', 'c', 'c', 'd', 'e'});
+      }
     }
   }
 }
@@ -694,16 +738,23 @@ SCENARIO("zip_view zips three containers and transforms (unary)", "[algorithms]"
     std::vector<double> v2{4.1, 5.2, 6.3, 7.4};
     std::list<char>     v3{'a', 'b', 'c', 'd', 'e'};
 
-    THEN("we can transform the zipped view")
+    WHEN("we transform the zipped views with a unary operation")
     {
-      auto               zip = gst::ranges::views::zip(v1, v2, v3);
+      auto               multiply_first_by_2 = [](auto const& t) { return std::get<0>(t) * 2; };
+      auto               zip                 = gst::ranges::views::zip(v1, v2, v3);
       std::array<int, 3> res;
+      auto [itr1, itr2] = std::ranges::transform(zip, res.begin(), multiply_first_by_2);
 
-      auto itr = std::transform(
-        zip.begin(), zip.end(), res.begin(), [](auto const& t) { return std::get<0>(t) * 2; });
+      THEN("the returned iterators point to the end of the range")
+      {
+        REQUIRE(itr1 == zip.end());
+        REQUIRE(itr2 == res.end());
+      }
 
-      REQUIRE(res == std::array<int, 3>{2, 4, 6});
-      REQUIRE(itr == res.end());
+      THEN("the transformation is applied correctly")
+      {
+        REQUIRE(res == std::array<int, 3>{2, 4, 6});
+      }
     }
   }
 }
@@ -715,23 +766,25 @@ SCENARIO("zip_view zips two containers and transforms (binary)", "[algorithms]")
     std::vector<int>    v1{1, 2, 3};
     std::vector<double> v2{4.1, 5.2, 6.3};
 
-    THEN("we can transform the zipped views with a binary operation")
+    WHEN("we transform the zipped views with a binary operation")
     {
-      auto zip1 = gst::ranges::views::zip(v1);
-      auto zip2 = gst::ranges::views::zip(v2);
+      auto add_firsts = [](auto const& t1, auto const& t2)
+      { return std::get<0>(t1) + std::get<0>(t2); };
 
+      auto                zip1 = gst::ranges::views::zip(v1);
+      auto                zip2 = gst::ranges::views::zip(v2);
       std::vector<double> res(v1.size());
       std::vector<double> ref{1 + 4.1, 2 + 5.2, 3 + 6.3};
+      auto [itr1, itr2, itr3] = std::ranges::transform(zip1, zip2, res.begin(), add_firsts);
 
-      auto itr = std::transform(zip1.begin(),
-                                zip1.end(),
-                                zip2.begin(),
-                                res.begin(),
-                                [](auto const& t1, auto const& t2)
-                                { return std::get<0>(t1) + std::get<0>(t2); });
+      THEN("the returned iterators point to the end of the ranges")
+      {
+        REQUIRE(itr1 == zip1.end());
+        REQUIRE(itr2 == zip2.end());
+        REQUIRE(itr3 == res.end());
+      }
 
-      REQUIRE(res == ref);
-      REQUIRE(itr == res.end());
+      THEN("the transformation is applied correctly") { REQUIRE(res == ref); }
     }
   }
 }
@@ -741,24 +794,24 @@ SCENARIO("std::equal_range works on sorted zip_view", "[algorithms][binary_searc
   GIVEN("Sorted vectors with duplicates")
   {
     std::vector<int>    v1{1, 2, 2, 2, 3, 4, 5};
-    std::vector<double> v2{1.1, 2.1, 2.2, 2.3, 3.3, 4.4, 5.5};
-    std::vector<char>   v3{'a', 'b', 'c', 'd', 'e', 'f', 'g'};
+    std::vector<double> v2{1.1, 2.2, 2.2, 2.2, 3.3, 4.4, 5.5};
+    std::vector<char>   v3{'a', 'b', 'b', 'b', 'c', 'd', 'e'};
 
-    WHEN("we find the equal range for value 2")
+    WHEN("we find the equal range for a specific tuple")
     {
-      auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      auto range  = std::equal_range(zipped.begin(),
-                                    zipped.end(),
-                                    std::make_tuple(2, 0.0, '\0'),
-                                    [](auto const& a, auto const& b)
-                                    { return std::get<0>(a) < std::get<0>(b); });
+      auto to_find      = std::make_tuple(2, 2.2, 'b');
+      auto zipped       = gst::ranges::views::zip(v1, v2, v3);
+      auto [itr1, itr2] = std::ranges::equal_range(zipped, to_find, std::less<>{});
 
-      THEN("we get the range of all elements equal to 2")
+      THEN("the range contains the correct number of elements")
       {
-        REQUIRE(std::distance(range.first, range.second) == 3);
-        REQUIRE(std::get<0>(*range.first) == 2);
-        REQUIRE(std::get<1>(*range.first) == Catch::Approx(2.1));
-        REQUIRE(std::get<2>(*range.first) == 'b');
+        REQUIRE(std::ranges::distance(itr1, itr2) == 3);
+      }
+
+      THEN("all elements in the range are equal to the searched value")
+      {
+        auto const equal_to_to_find = [&to_find](auto const& t) { return t == to_find; };
+        REQUIRE(std::ranges::all_of(itr1, itr2, equal_to_to_find));
       }
     }
   }
@@ -768,26 +821,26 @@ SCENARIO("std::is_partitioned works on zip_view", "[algorithms][partition]")
 {
   GIVEN("A partitioned and a non-partitioned sequence")
   {
+    auto                is_even_first = [](auto const& t) { return std::get<0>(t) % 2 == 0; };
     std::vector<int>    partitioned_v1{2, 4, 6, 1, 3, 5};
     std::vector<double> partitioned_v2{2.2, 4.4, 6.6, 1.1, 3.3, 5.5};
-
     std::vector<int>    not_partitioned_v1{1, 2, 3, 4, 5, 6};
     std::vector<double> not_partitioned_v2{1.1, 2.2, 3.3, 4.4, 5.5, 6.6};
 
-    THEN("is_partitioned returns true for partitioned sequence")
+    WHEN("is_partitioned is called on a partitioned sequence")
     {
       auto zipped = gst::ranges::views::zip(partitioned_v1, partitioned_v2);
-      bool result = std::is_partitioned(
-        zipped.begin(), zipped.end(), [](auto const& t) { return std::get<0>(t) % 2 == 0; });
-      REQUIRE(result == true);
+      bool result = std::ranges::is_partitioned(zipped, is_even_first);
+
+      THEN("the result is true") { REQUIRE(result == true); }
     }
 
-    THEN("is_partitioned returns false for non-partitioned sequence")
+    WHEN("is_partitioned is called on a non-partitioned sequence")
     {
       auto zipped = gst::ranges::views::zip(not_partitioned_v1, not_partitioned_v2);
-      bool result = std::is_partitioned(
-        zipped.begin(), zipped.end(), [](auto const& t) { return std::get<0>(t) % 2 == 0; });
-      REQUIRE(result == false);
+      bool result = std::ranges::is_partitioned(zipped, is_even_first);
+
+      THEN("the result is false") { REQUIRE(result == false); }
     }
   }
 }
@@ -802,18 +855,15 @@ SCENARIO("std::is_sorted_until works on zip_view", "[algorithms][sorted]")
 
     WHEN("we find where the sequence stops being sorted")
     {
+      auto cmp_by_first = [](auto const& a, auto const& b)
+      { return std::get<0>(a) < std::get<0>(b); };
       auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      auto it     = std::is_sorted_until(zipped.begin(),
-                                     zipped.end(),
-                                     [](auto const& a, auto const& b)
-                                     { return std::get<0>(a) < std::get<0>(b); });
+      auto it     = std::ranges::is_sorted_until(zipped, cmp_by_first);
 
       THEN("we find the first unsorted element")
       {
-        REQUIRE(std::distance(zipped.begin(), it) == 3);
-        REQUIRE(std::get<0>(*it) == 2);
-        REQUIRE(std::get<1>(*it) == Catch::Approx(2.2));
-        REQUIRE(std::get<2>(*it) == 'd');
+        REQUIRE(it == std::ranges::next(zipped.begin(), 3));
+        REQUIRE((*it == std::make_tuple(2, Catch::Approx(2.2), 'd')));
       }
     }
   }
@@ -824,41 +874,34 @@ SCENARIO("std::lower_bound and std::upper_bound work on sorted zip_view",
 {
   GIVEN("Sorted vectors")
   {
+    auto cmp_by_first = [](auto const& a, auto const& b)
+    { return std::get<0>(a) < std::get<0>(b); };
+
     std::vector<int>    v1{1, 2, 2, 3, 4, 4, 4, 5};
     std::vector<double> v2{1.1, 2.1, 2.2, 3.3, 4.1, 4.2, 4.3, 5.5};
     std::vector<char>   v3{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'};
-
-    auto zipped = gst::ranges::views::zip(v1, v2, v3);
+    auto                zipped  = gst::ranges::views::zip(v1, v2, v3);
+    auto                to_find = std::make_tuple(4, 0.0, '\0');
 
     WHEN("we find lower_bound for value 4")
     {
-      auto it = std::lower_bound(zipped.begin(),
-                                 zipped.end(),
-                                 std::make_tuple(4, 0.0, '\0'),
-                                 [](auto const& a, auto const& b)
-                                 { return std::get<0>(a) < std::get<0>(b); });
+      auto it = std::ranges::lower_bound(zipped, to_find, cmp_by_first);
 
       THEN("we get the first element not less than 4")
       {
-        REQUIRE(std::get<0>(*it) == 4);
-        REQUIRE(std::get<1>(*it) == Catch::Approx(4.1));
-        REQUIRE(std::get<2>(*it) == 'e');
+        REQUIRE(it != zipped.end());
+        REQUIRE((*it == std::make_tuple(4, Catch::Approx(4.1), 'e')));
       }
     }
 
     WHEN("we find upper_bound for value 4")
     {
-      auto it = std::upper_bound(zipped.begin(),
-                                 zipped.end(),
-                                 std::make_tuple(4, 0.0, '\0'),
-                                 [](auto const& a, auto const& b)
-                                 { return std::get<0>(a) < std::get<0>(b); });
+      auto it = std::ranges::upper_bound(zipped, to_find, cmp_by_first);
 
       THEN("we get the first element greater than 4")
       {
-        REQUIRE(std::get<0>(*it) == 5);
-        REQUIRE(std::get<1>(*it) == Catch::Approx(5.5));
-        REQUIRE(std::get<2>(*it) == 'h');
+        REQUIRE(it != zipped.end());
+        REQUIRE((*it == std::make_tuple(5, Catch::Approx(5.5), 'h')));
       }
     }
   }
@@ -868,6 +911,9 @@ SCENARIO("std::max_element works on zip_view", "[algorithms][minmax]")
 {
   GIVEN("Three vectors")
   {
+    auto cmp_by_first = [](auto const& a, auto const& b)
+    { return std::get<0>(a) < std::get<0>(b); };
+
     std::vector<int>    v1{3, 1, 4, 1, 5, 9, 2};
     std::vector<double> v2{3.3, 1.1, 4.4, 1.2, 5.5, 9.9, 2.2};
     std::vector<char>   v3{'c', 'a', 'd', 'b', 'e', 'i', 'f'};
@@ -876,17 +922,12 @@ SCENARIO("std::max_element works on zip_view", "[algorithms][minmax]")
 
     WHEN("we find the maximum element by first component")
     {
-      auto it = std::max_element(zipped.begin(),
-                                 zipped.end(),
-                                 [](auto const& a, auto const& b)
-                                 { return std::get<0>(a) < std::get<0>(b); });
+      auto it = std::ranges::max_element(zipped, cmp_by_first);
 
       THEN("we get the tuple with maximum first element")
       {
         REQUIRE(it != zipped.end());
-        REQUIRE(std::get<0>(*it) == 9);
-        REQUIRE(std::get<1>(*it) == Catch::Approx(9.9));
-        REQUIRE(std::get<2>(*it) == 'i');
+        REQUIRE((*it == std::make_tuple(9, Catch::Approx(9.9), 'i')));
       }
     }
   }
@@ -904,17 +945,14 @@ SCENARIO("std::min_element works on zip_view", "[algorithms][minmax]")
 
     WHEN("we find the minimum element by first component")
     {
-      auto it = std::min_element(zipped.begin(),
-                                 zipped.end(),
-                                 [](auto const& a, auto const& b)
-                                 { return std::get<0>(a) < std::get<0>(b); });
+      auto cmp_by_first = [](auto const& a, auto const& b)
+      { return std::get<0>(a) < std::get<0>(b); };
+      auto it = std::ranges::min_element(zipped, cmp_by_first);
 
       THEN("we get the tuple with minimum first element")
       {
         REQUIRE(it != zipped.end());
-        REQUIRE(std::get<0>(*it) == 1);
-        REQUIRE(std::get<1>(*it) == Catch::Approx(1.1));
-        REQUIRE(std::get<2>(*it) == 'a');
+        REQUIRE((*it == std::make_tuple(1, Catch::Approx(1.1), 'a')));
       }
     }
   }
@@ -930,21 +968,17 @@ SCENARIO("std::minmax_element works on zip_view", "[algorithms][minmax]")
 
     WHEN("we find both min and max elements")
     {
-      auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      auto result = std::minmax_element(zipped.begin(),
-                                        zipped.end(),
-                                        [](auto const& a, auto const& b)
-                                        { return std::get<0>(a) < std::get<0>(b); });
+      auto cmp_by_first = [](auto const& a, auto const& b)
+      { return std::get<0>(a) < std::get<0>(b); };
+      auto zipped          = gst::ranges::views::zip(v1, v2, v3);
+      auto [first, second] = std::ranges::minmax_element(zipped, cmp_by_first);
 
       THEN("we get both minimum and maximum")
       {
-        REQUIRE(std::get<0>(*result.first) == 1);
-        REQUIRE(std::get<1>(*result.first) == Catch::Approx(1.1));
-        REQUIRE(std::get<2>(*result.first) == 'a');
-
-        REQUIRE(std::get<0>(*result.second) == 9);
-        REQUIRE(std::get<1>(*result.second) == Catch::Approx(9.9));
-        REQUIRE(std::get<2>(*result.second) == 'i');
+        REQUIRE(first != zipped.end());
+        REQUIRE(second != zipped.end());
+        REQUIRE((*first == std::make_tuple(1, Catch::Approx(1.1), 'a')));
+        REQUIRE((*second == std::make_tuple(9, Catch::Approx(9.9), 'i')));
       }
     }
   }
@@ -955,41 +989,119 @@ SCENARIO("std::next_permutation and std::prev_permutation work on zip_view",
 {
   GIVEN("Three sorted vectors")
   {
-    std::vector<int>  v1{1, 2, 3};
-    std::vector<char> v2{'a', 'b', 'c'};
+    auto cmp_by_first = [](auto const& a, auto const& b)
+    { return std::get<0>(a) < std::get<0>(b); };
 
-    WHEN("we generate the next permutation")
+    WHEN("we generate permutations with next_permutation")
     {
-      auto zipped = gst::ranges::views::zip(v1, v2);
-      bool result = std::next_permutation(zipped.begin(),
-                                          zipped.end(),
-                                          [](auto const& a, auto const& b)
-                                          { return std::get<0>(a) < std::get<0>(b); });
+      std::vector<int>  v1{1, 2, 3};
+      std::vector<char> v2{'a', 'b', 'c'};
+      auto              zipped = gst::ranges::views::zip(v1, v2);
 
-      THEN("all vectors are permuted together")
+      THEN("the first permutation is generated correctly")
       {
-        REQUIRE(result == true);
+        auto result = std::ranges::next_permutation(zipped, cmp_by_first);
+        REQUIRE(result.found);
+        REQUIRE(result.in == zipped.end());
         REQUIRE(v1 == std::vector<int>{1, 3, 2});
         REQUIRE(v2 == std::vector<char>{'a', 'c', 'b'});
+
+        AND_THEN("the second permutation is generated correctly")
+        {
+          result = std::ranges::next_permutation(zipped, cmp_by_first);
+          REQUIRE(result.found);
+          REQUIRE(result.in == zipped.end());
+          REQUIRE(v1 == std::vector<int>{2, 1, 3});
+          REQUIRE(v2 == std::vector<char>{'b', 'a', 'c'});
+
+          AND_THEN("the third permutation is generated correctly")
+          {
+            result = std::ranges::next_permutation(zipped, cmp_by_first);
+            REQUIRE(result.found);
+            REQUIRE(result.in == zipped.end());
+            REQUIRE(v1 == std::vector<int>{2, 3, 1});
+            REQUIRE(v2 == std::vector<char>{'b', 'c', 'a'});
+
+            AND_THEN("the fourth permutation is generated correctly")
+            {
+              result = std::ranges::next_permutation(zipped, cmp_by_first);
+              REQUIRE(result.found);
+              REQUIRE(result.in == zipped.end());
+              REQUIRE(v1 == std::vector<int>{3, 1, 2});
+              REQUIRE(v2 == std::vector<char>{'c', 'a', 'b'});
+
+              AND_THEN("the last permutation is generated correctly")
+              {
+                result = std::ranges::next_permutation(zipped, cmp_by_first);
+                REQUIRE(result.found);
+                REQUIRE(result.in == zipped.end());
+                REQUIRE(v1 == std::vector<int>{3, 2, 1});
+                REQUIRE(v2 == std::vector<char>{'c', 'b', 'a'});
+
+                AND_THEN("we wrap around to the first permutation")
+                {
+                  result = std::ranges::next_permutation(zipped, cmp_by_first);
+                  REQUIRE_FALSE(result.found);
+                  REQUIRE(result.in == zipped.end());
+                  REQUIRE(v1 == std::vector<int>{1, 2, 3});
+                  REQUIRE(v2 == std::vector<char>{'a', 'b', 'c'});
+                }
+              }
+            }
+          }
+        }
       }
     }
 
-    WHEN("we generate the previous permutation from non-first permutation")
+    WHEN("we generate permutations with prev_permutation")
     {
-      v1 = {2, 1, 3};
-      v2 = {'b', 'a', 'c'};
+      std::vector<int>  v1     = {1, 2, 3};
+      std::vector<char> v2     = {'a', 'b', 'c'};
+      auto              zipped = gst::ranges::views::zip(v1, v2);
 
-      auto zipped = gst::ranges::views::zip(v1, v2);
-      bool result = std::prev_permutation(zipped.begin(),
-                                          zipped.end(),
-                                          [](auto const& a, auto const& b)
-                                          { return std::get<0>(a) < std::get<0>(b); });
-
-      THEN("all vectors are permuted together")
+      THEN("we wrap around to the last permutation")
       {
-        REQUIRE(result == true);
-        REQUIRE(v1 == std::vector<int>{1, 3, 2});
-        REQUIRE(v2 == std::vector<char>{'a', 'c', 'b'});
+        auto result = std::ranges::prev_permutation(zipped, cmp_by_first);
+        REQUIRE_FALSE(result.found);
+        REQUIRE(result.in == zipped.end());
+        REQUIRE(v1 == std::vector<int>{3, 2, 1});
+        REQUIRE(v2 == std::vector<char>{'c', 'b', 'a'});
+
+        AND_THEN("the second previous permutation is generated correctly")
+        {
+          result = std::ranges::prev_permutation(zipped, cmp_by_first);
+          REQUIRE(result.found);
+          REQUIRE(result.in == zipped.end());
+          REQUIRE(v1 == std::vector<int>{3, 1, 2});
+          REQUIRE(v2 == std::vector<char>{'c', 'a', 'b'});
+
+          AND_THEN("the third previous permutation is generated correctly")
+          {
+            result = std::ranges::prev_permutation(zipped, cmp_by_first);
+            REQUIRE(result.found);
+            REQUIRE(result.in == zipped.end());
+            REQUIRE(v1 == std::vector<int>{2, 3, 1});
+            REQUIRE(v2 == std::vector<char>{'b', 'c', 'a'});
+
+            AND_THEN("the fourth previous permutation is generated correctly")
+            {
+              result = std::ranges::prev_permutation(zipped, cmp_by_first);
+              REQUIRE(result.found);
+              REQUIRE(result.in == zipped.end());
+              REQUIRE(v1 == std::vector<int>{2, 1, 3});
+              REQUIRE(v2 == std::vector<char>{'b', 'a', 'c'});
+
+              AND_THEN("the last previous permutation is generated correctly")
+              {
+                result = std::ranges::prev_permutation(zipped, cmp_by_first);
+                REQUIRE(result.found);
+                REQUIRE(result.in == zipped.end());
+                REQUIRE(v1 == std::vector<int>{1, 3, 2});
+                REQUIRE(v2 == std::vector<char>{'a', 'c', 'b'});
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -1004,18 +1116,13 @@ SCENARIO("std::nth_element works on random access zip_view", "[algorithms][nth_e
 
     WHEN("we find the 3rd smallest element")
     {
+      auto cmp_by_first = [](auto const& a, auto const& b)
+      { return std::get<0>(a) < std::get<0>(b); };
       auto zipped = gst::ranges::views::zip(keys, values);
-      std::nth_element(zipped.begin(),
-                       zipped.begin() + 3,
-                       zipped.end(),
-                       [](auto const& a, auto const& b)
-                       { return std::get<0>(a) < std::get<0>(b); });
+      std::nth_element(zipped.begin(), zipped.begin() + 3, zipped.end(), cmp_by_first);
 
       THEN("the element at position 3 has key 5 (4th smallest)")
       {
-        // After nth_element, position 3 should have the element that would be there if sorted
-        // Sorted keys would be: 1, 2, 3, 5, 7, 8, 9
-        // So position 3 (0-indexed) should have key 5
         REQUIRE(keys[3] == 5);
         REQUIRE(values[3] == '5');
       }
@@ -1033,12 +1140,15 @@ SCENARIO("std::partial_sort works on random access zip_view", "[algorithms][sort
 
     WHEN("we partially sort the first 3 elements")
     {
+      auto cmp_by_first = [](auto const& a, auto const& b)
+      { return std::get<0>(a) < std::get<0>(b); };
       auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      std::partial_sort(zipped.begin(),
-                        zipped.begin() + 3,
-                        zipped.end(),
-                        [](auto const& a, auto const& b)
-                        { return std::get<0>(a) < std::get<0>(b); });
+      auto end    = std::ranges::partial_sort(zipped, std::next(zipped.begin(), 3), cmp_by_first);
+
+      THEN("the returned iterator points to the end of the sorted range")
+      {
+        REQUIRE(end == zipped.end());
+      }
 
       THEN("the first 3 elements are the smallest, in sorted order")
       {
@@ -1057,13 +1167,15 @@ SCENARIO("std::partition works on zip_view", "[algorithms][partition]")
   {
     std::vector<int>         v1{1, 2, 3, 4, 5, 6};
     std::vector<std::string> v2{"one", "two", "three", "four", "five", "six"};
-    std::vector<char>        v3{'a', 'b', 'c', 'd', 'e', 'f'};
+    std::vector<short>       v3{'a', 'b', 'c', 'd', 'e', 'f'};
 
     WHEN("we partition by even numbers")
     {
-      auto is_even  = [](auto const& t) { return std::get<0>(t) % 2 == 0; };
-      auto zipped   = gst::ranges::views::zip(v1, v2, v3);
-      auto it_bound = std::partition(zipped.begin(), zipped.end(), is_even);
+      auto is_even         = [](auto const& t) { return std::get<0>(t) % 2 == 0; };
+      auto zipped          = gst::ranges::views::zip(v1, v2, v3);
+      auto [it_bound, end] = std::ranges::partition(zipped, is_even);
+
+      THEN("the end iterator remains unchanged") { REQUIRE(end == zipped.end()); }
 
       THEN("the return value points to the partition boundary")
       {
@@ -1072,10 +1184,10 @@ SCENARIO("std::partition works on zip_view", "[algorithms][partition]")
 
       THEN("even elements come first in the first container")
       {
-        REQUIRE(std::all_of(
-          v1.begin(), std::next(v1.begin(), 3), [](auto const arg) { return arg % 2 == 0; }));
-        REQUIRE(std::all_of(
-          std::next(v1.begin(), 3), v1.end(), [](auto const arg) { return arg % 2 != 0; }));
+        auto is_even_val = [](auto const arg) { return arg % 2 == 0; };
+        auto is_odd_val  = [](auto const arg) { return arg % 2 != 0; };
+        REQUIRE(std::ranges::all_of(v1.begin(), std::next(v1.begin(), 3), is_even_val));
+        REQUIRE(std::ranges::all_of(std::next(v1.begin(), 3), v1.end(), is_odd_val));
       }
     }
   }
@@ -1090,15 +1202,14 @@ SCENARIO("std::partition_point works on partitioned zip_view", "[algorithms][par
 
     WHEN("we find the partition point")
     {
-      auto zipped = gst::ranges::views::zip(v1, v2);
-      auto it     = std::partition_point(
-        zipped.begin(), zipped.end(), [](auto const& t) { return std::get<0>(t) % 2 == 0; });
+      auto zipped        = gst::ranges::views::zip(v1, v2);
+      auto is_even_first = [](auto const& t) { return std::get<0>(t) % 2 == 0; };
+      auto it            = std::ranges::partition_point(zipped, is_even_first);
 
       THEN("we find the boundary between partitions")
       {
-        REQUIRE(std::distance(zipped.begin(), it) == 3);
-        REQUIRE(std::get<0>(*it) == 1);
-        REQUIRE(std::get<1>(*it) == Catch::Approx(1.1));
+        REQUIRE(it == std::next(zipped.begin(), 3));
+        REQUIRE((*it == std::make_tuple(1, Catch::Approx(1.1))));
       }
     }
   }
@@ -1113,8 +1224,9 @@ SCENARIO("sort works on random access zip_view", "[algorithms]")
 
     WHEN("we sort the zip_view by the key")
     {
-      auto zipped = gst::ranges::views::zip(keys, values);
-      std::ranges::sort(zipped, std::less<>(), [](auto const& t) { return std::get<0>(t); });
+      auto zipped     = gst::ranges::views::zip(keys, values);
+      auto proj_first = [](auto const& t) { return std::get<0>(t); };
+      std::ranges::sort(zipped, std::less<>(), proj_first);
 
       THEN("both containers are sorted according to the keys")
       {
@@ -1132,8 +1244,9 @@ SCENARIO("sort works on random access zip_view", "[algorithms]")
 
     WHEN("we sort by key")
     {
-      auto zipped = gst::ranges::views::zip(keys, names, pairs);
-      std::ranges::sort(zipped, std::less<>(), [](auto const& t) { return std::get<0>(t); });
+      auto zipped     = gst::ranges::views::zip(keys, names, pairs);
+      auto proj_first = [](auto const& t) { return std::get<0>(t); };
+      std::ranges::sort(zipped, std::less<>(), proj_first);
 
       THEN("all three containers are sorted consistently")
       {
@@ -1156,13 +1269,14 @@ SCENARIO("std::stable_partition works on zip_view", "[algorithms][partition]")
 
     WHEN("we stable partition by even numbers")
     {
-      auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      auto it     = std::stable_partition(
-        zipped.begin(), zipped.end(), [](auto const& t) { return std::get<0>(t) % 2 == 0; });
+      auto zipped        = gst::ranges::views::zip(v1, v2, v3);
+      auto is_even_first = [](auto const& t) { return std::get<0>(t) % 2 == 0; };
+      auto [pivot, end]  = std::ranges::stable_partition(zipped, is_even_first);
 
       THEN("the return value points to the partition boundary")
       {
-        REQUIRE(it == std::next(zipped.begin(), 3));
+        REQUIRE(pivot != zipped.end());
+        REQUIRE(pivot == std::next(zipped.begin(), 3));
       }
 
       THEN("even elements come first, order preserved, all vectors partitioned")
@@ -1185,8 +1299,9 @@ SCENARIO("std::stable_sort works on random access zip_view", "[algorithms][sort]
 
     WHEN("we stable sort by the first element")
     {
-      auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      std::ranges::stable_sort(zipped, std::less<>(), [](auto const& t) { return std::get<0>(t); });
+      auto zipped     = gst::ranges::views::zip(v1, v2, v3);
+      auto proj_first = [](auto const& t) { return std::get<0>(t); };
+      std::ranges::stable_sort(zipped, std::less<>(), proj_first);
 
       THEN("equal elements maintain their relative order")
       {
@@ -1208,23 +1323,24 @@ SCENARIO("std::unique works on sorted zip_view", "[algorithms][unique]")
 
     WHEN("we remove consecutive duplicates based on first element")
     {
-      auto zipped = gst::ranges::views::zip(v1, v2, v3);
-      auto it =
-        std::unique(zipped.begin(),
-                    zipped.end(),
-                    [](auto const& a, auto const& b) { return std::get<0>(a) == std::get<0>(b); });
+      auto eq_by_first = [](auto const& a, auto const& b)
+      { return std::get<0>(a) == std::get<0>(b); };
+      auto zipped           = gst::ranges::views::zip(v1, v2, v3);
+      auto [new_last, last] = std::ranges::unique(zipped, eq_by_first);
 
-      THEN("duplicates are removed from all vectors")
+      THEN("the returned iterator points to the new end of the range")
       {
-        auto new_size = std::distance(zipped.begin(), it);
-        REQUIRE(new_size == 4);
-        v1.erase(v1.begin() + new_size, v1.end());
-        v2.erase(v2.begin() + new_size, v2.end());
-        v3.erase(v3.begin() + new_size, v3.end());
+        REQUIRE(new_last == std::next(zipped.begin(), 4));
+        REQUIRE(last == zipped.end());
+      }
 
-        REQUIRE(v1 == std::vector<int>{1, 2, 3, 4});
-        REQUIRE(v2 == std::vector<std::string>{"a", "c", "e", "g"});
-        REQUIRE(v3 == std::vector<double>{1.1, 2.1, 3.1, 4.1});
+      THEN("consecutive duplicates are removed")
+      {
+        REQUIRE(std::vector<int>(v1.begin(), v1.begin() + 4) == std::vector<int>{1, 2, 3, 4});
+        REQUIRE(std::vector<std::string>(v2.begin(), v2.begin() + 4) ==
+                std::vector<std::string>{"a", "c", "e", "g"});
+        REQUIRE(std::vector<double>(v3.begin(), v3.begin() + 4) ==
+                std::vector<double>{1.1, 2.1, 3.1, 4.1});
       }
     }
   }

--- a/tests/temp.cpp
+++ b/tests/temp.cpp
@@ -173,29 +173,32 @@ SCENARIO("zip_view inline usage with STL algorithms", "[temporaries]")
   {
     THEN("for_each works with inline temporary zip_view")
     {
-      int sum = 0;
+      int  sum             = 0;
+      auto add_pair_to_sum = [&](auto const& t) { sum += std::get<0>(t) + std::get<1>(t); };
       std::ranges::for_each(
         gst::ranges::views::zip(std::array<int, 3>{1, 2, 3}, std::array<char, 3>{'a', 'b', 'c'}),
-        [&](auto const& t) { sum += std::get<0>(t) + std::get<1>(t); });
+        add_pair_to_sum);
       REQUIRE(sum == (1 + 'a') + (2 + 'b') + (3 + 'c'));
     }
 
     THEN("transform works with inline temporary zip_view")
     {
       std::vector<int> out;
+      auto             sum_pair = [](auto const& t) { return std::get<0>(t) + std::get<1>(t); };
       std::ranges::transform(
         gst::ranges::views::zip(std::array<int, 3>{1, 2, 3}, std::array<char, 3>{'a', 'b', 'c'}),
         std::back_inserter(out),
-        [](auto const& t) { return std::get<0>(t) + std::get<1>(t); });
+        sum_pair);
       REQUIRE(out == std::vector<int>{1 + 'a', 2 + 'b', 3 + 'c'});
     }
 
     THEN("fold_left works with inline temporary zip_view")
     {
-      int dot = std::ranges::fold_left(
+      auto dot_acc = [](int acc, auto const& t) { return acc + (std::get<0>(t) * std::get<1>(t)); };
+      int  dot     = std::ranges::fold_left(
         gst::ranges::views::zip(std::array<int, 3>{1, 2, 3}, std::array<char, 3>{'a', 'b', 'c'}),
         0,
-        [](int acc, auto const& t) { return acc + (std::get<0>(t) * std::get<1>(t)); });
+        dot_acc);
       REQUIRE(dot == (1 * 'a' + 2 * 'b' + 3 * 'c'));
     }
   }


### PR DESCRIPTION
- Removed global CMAKE_CXX_STANDARD settings from root CMakeLists.txt
- Removed C++ standard flags from CI workflow configurations
- Each target now explicitly sets its C++ standard via set_target_properties
- Added CODE_COVERAGE option (disabled by default, enabled in CI for GCC/ubuntu-latest)
- Updated Copilot instructions to reflect opt-in coverage behavior