### PR TITLE
Rework build system and CI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,10 +76,10 @@ clang-tidy -p build path/to/file.cpp
 
 ### Coverage / sanitizers
 
-- Coverage is enabled for `ZipViewTests` on GCC/Clang via the `CODE_COVERAGE` option (default ON in `tests/CMakeLists.txt`). Disable it if you want a “normal” build:
+- Coverage is disabled by default. Enable it for `ZipViewTests` on GCC/Clang via the `CODE_COVERAGE` option:
 
 ```bash
-cmake -S . -B build -DCODE_COVERAGE=OFF
+cmake -S . -B build -DCODE_COVERAGE=ON
 ```
 
 - If `gcovr` is installed, a `coverage` target may be available:

--- a/.github/scripts/merge_benchmarks.py
+++ b/.github/scripts/merge_benchmarks.py
@@ -21,16 +21,6 @@ def load_json_if_exists(path):
         return {"error": f"failed to parse {path}: {e}"}
 
 
-def load_console_if_exists(path):
-    if not os.path.exists(path):
-        return None
-    try:
-        with open(path) as f:
-            return f.read()
-    except Exception as e:
-        return f"failed to read {path}: {e}"
-
-
 def create_summary(merged, out_path):
     lines = []
     lines.append("## Benchmark Results Summary (All Architectures)\n")
@@ -48,13 +38,7 @@ def create_summary(merged, out_path):
                 lines.append(f"{name}: {time} {unit}")
             lines.append("```\n")
         else:
-            # Fallback: include a short note and any console snippet if present
-            console = block.get("console")
-            if console:
-                lines.append("No parsed benchmarks; console output follows (first 200 chars):\n")
-                lines.append(console[:200].replace('```', "`` `") + "\n")
-            else:
-                lines.append("No benchmark data found\n")
+            lines.append("No benchmark data found\n")
     with open(out_path, "w") as f:
         f.write("\n".join(lines))
 
@@ -73,30 +57,17 @@ def main():
     os.makedirs(out_dir, exist_ok=True)
 
     merged = []
+    console_lines = []
 
     for arch in arches:
         json_path = os.path.join(artifacts_dir, f"benchmark-results-{arch}", "benchmark_results.json")
-        console_path = os.path.join(artifacts_dir, f"benchmark-results-{arch}", "benchmark_console.txt")
 
         data = load_json_if_exists(json_path)
-        console = None
-        if data is None:
-            # try to fallback to console
-            console = load_console_if_exists(console_path)
-            if console is not None:
-                entry = {"arch": arch, "results": {"error": "no json, console available"}, "console": console}
-            else:
-                entry = {"arch": arch, "results": None}
-        else:
-            entry = {"arch": arch, "results": data}
-            # still attach console snippet if available (handy for debugging)
-            console = load_console_if_exists(console_path)
-            if console is not None:
-                entry["console"] = console[:1000]
+        entry = {"arch": arch, "results": data}
         merged.append(entry)
 
-    merged_path = os.path.join(out_dir, "benchmark_results_merged.json")
-    with open(merged_path, "w") as f:
+    merged_json_path = os.path.join(out_dir, "benchmark_results_merged.json")
+    with open(merged_json_path, "w") as f:
         json.dump(merged, f, indent=2)
 
     # Create human-readable summary
@@ -104,8 +75,7 @@ def main():
     create_summary(merged, summary_path)
 
     # Print results for logs
-    print("Wrote:", merged_path)
-    print(open(merged_path).read())
+    print("Wrote:", merged_json_path)
     print("---\nSummary:\n")
     with open(summary_path) as f:
         print(f.read())

--- a/.github/scripts/merge_benchmarks.py
+++ b/.github/scripts/merge_benchmarks.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Merge per-arch Google Benchmark JSON artifacts into a single JSON and create a simple markdown summary.
+
+Usage: merge_benchmarks.py --artifacts-dir artifacts --out-dir merged
+"""
+import argparse
+import json
+import os
+import sys
+
+DEFAULT_ARCHES = ["x86_64", "x86_32", "arm64", "arm32"]
+
+
+def load_json_if_exists(path):
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception as e:
+        return {"error": f"failed to parse {path}: {e}"}
+
+
+def load_console_if_exists(path):
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            return f.read()
+    except Exception as e:
+        return f"failed to read {path}: {e}"
+
+
+def create_summary(merged, out_path):
+    lines = []
+    lines.append("## Benchmark Results Summary (All Architectures)\n")
+    for block in merged:
+        arch = block.get("arch")
+        results = block.get("results") or {}
+        lines.append(f"### {arch}\n")
+        benches = results.get("benchmarks") if isinstance(results, dict) else []
+        if benches:
+            lines.append("```text")
+            for b in benches:
+                name = b.get("name")
+                time = b.get("real_time")
+                unit = b.get("time_unit")
+                lines.append(f"{name}: {time} {unit}")
+            lines.append("```\n")
+        else:
+            # Fallback: include a short note and any console snippet if present
+            console = block.get("console")
+            if console:
+                lines.append("No parsed benchmarks; console output follows (first 200 chars):\n")
+                lines.append(console[:200].replace('```', "`` `") + "\n")
+            else:
+                lines.append("No benchmark data found\n")
+    with open(out_path, "w") as f:
+        f.write("\n".join(lines))
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--artifacts-dir", default="artifacts", help="Path where per-arch artifact folders live")
+    p.add_argument("--out-dir", default="merged", help="Path where merged outputs are written")
+    p.add_argument("--arches", default=','.join(DEFAULT_ARCHES), help="Comma-separated list of architectures to look for")
+    args = p.parse_args()
+
+    artifacts_dir = args.artifacts_dir
+    out_dir = args.out_dir
+    arches = [a.strip() for a in args.arches.split(',') if a.strip()]
+
+    os.makedirs(out_dir, exist_ok=True)
+
+    merged = []
+
+    for arch in arches:
+        json_path = os.path.join(artifacts_dir, f"benchmark-results-{arch}", "benchmark_results.json")
+        console_path = os.path.join(artifacts_dir, f"benchmark-results-{arch}", "benchmark_console.txt")
+
+        data = load_json_if_exists(json_path)
+        console = None
+        if data is None:
+            # try to fallback to console
+            console = load_console_if_exists(console_path)
+            if console is not None:
+                entry = {"arch": arch, "results": {"error": "no json, console available"}, "console": console}
+            else:
+                entry = {"arch": arch, "results": None}
+        else:
+            entry = {"arch": arch, "results": data}
+            # still attach console snippet if available (handy for debugging)
+            console = load_console_if_exists(console_path)
+            if console is not None:
+                entry["console"] = console[:1000]
+        merged.append(entry)
+
+    merged_path = os.path.join(out_dir, "benchmark_results_merged.json")
+    with open(merged_path, "w") as f:
+        json.dump(merged, f, indent=2)
+
+    # Create human-readable summary
+    summary_path = os.path.join(out_dir, "benchmark_summary.md")
+    create_summary(merged, summary_path)
+
+    # Print results for logs
+    print("Wrote:", merged_path)
+    print(open(merged_path).read())
+    print("---\nSummary:\n")
+    with open(summary_path) as f:
+        print(f.read())
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,7 +21,7 @@ jobs:
             runner: ubuntu-latest
             build_dir: build
             cmake_flags: ""
-            cxx_compiler: g++
+            cxx_compiler: clang++
             run_prefix: ""
           - arch: x86_32
             runner: ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
             runner: ubuntu-24.04-arm
             build_dir: build-arm
             cmake_flags: ""
-            cxx_compiler: g++
+            cxx_compiler: clang++
             run_prefix: ""
           - arch: arm32
             runner: ubuntu-24.04-arm
@@ -69,8 +69,6 @@ jobs:
       run: >
         cmake -B ${{ github.workspace }}/${{ matrix.build_dir }}
         -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }}
-        -DCMAKE_CXX_STANDARD=23
-        -DCMAKE_CXX_STANDARD_REQUIRED=True
         -DCMAKE_BUILD_TYPE=Release
         ${{ matrix.cmake_flags }}
         -S ${{ github.workspace }}
@@ -81,19 +79,22 @@ jobs:
     - name: Run Benchmarks
       run: |
         cd ${{ github.workspace }}/${{ matrix.build_dir }}
-        ${{ matrix.run_prefix }} ./benchmarks/ZipViewBenchmark --reporter console::out=-::colour-mode=none 2>&1 | tee benchmark_results.txt
+        ${{ matrix.run_prefix }} ./benchmarks/ZipViewBenchmark --benchmark_format=json --benchmark_out=benchmark_results.json 2>&1
 
     - name: Upload Benchmark Results
       uses: actions/upload-artifact@v4
       with:
         name: benchmark-results-${{ matrix.arch }}
-        path: ${{ github.workspace }}/${{ matrix.build_dir }}/benchmark_results.txt
+        path: |
+          ${{ github.workspace }}/${{ matrix.build_dir }}/benchmark_results.json
 
   merge-results:
     needs: benchmark
     if: success()
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4
+
     - name: Download all benchmark artifacts
       uses: actions/download-artifact@v4
       with:
@@ -104,56 +105,26 @@ jobs:
     - name: Merge benchmark results
       run: |
         mkdir -p merged
-        echo "# Combined Benchmark Results" > merged/benchmark_results_merged.txt
-        echo "Generated: $(date -u)" >> merged/benchmark_results_merged.txt
-        echo "" >> merged/benchmark_results_merged.txt
-
-        for arch in x86_64 x86_32 arm64 arm32; do
-          if [ -f "artifacts/benchmark-results-${arch}/benchmark_results.txt" ]; then
-            echo "========================================" >> merged/benchmark_results_merged.txt
-            echo "Architecture: ${arch}" >> merged/benchmark_results_merged.txt
-            echo "========================================" >> merged/benchmark_results_merged.txt
-            cat "artifacts/benchmark-results-${arch}/benchmark_results.txt" >> merged/benchmark_results_merged.txt
-            echo "" >> merged/benchmark_results_merged.txt
-          fi
-        done
-
-        cat merged/benchmark_results_merged.txt
+        python3 ./.github/scripts/merge_benchmarks.py --artifacts-dir artifacts --out-dir merged
+        echo "Merged files:" && ls -l merged || true
 
     - name: Create summary markdown
       run: |
-        cd merged
-        echo "## Benchmark Results Summary (All Architectures)" > benchmark_summary.md
-        echo "" >> benchmark_summary.md
-
-        for arch in x86_64 x86_32 arm64 arm32; do
-          if [ -f "../artifacts/benchmark-results-${arch}/benchmark_results.txt" ]; then
-            echo "### ${arch}" >> benchmark_summary.md
-            echo '```' >> benchmark_summary.md
-            grep -A 5 "benchmark name" "../artifacts/benchmark-results-${arch}/benchmark_results.txt" | head -100 >> benchmark_summary.md || echo "No benchmark data found" >> benchmark_summary.md
-            echo '```' >> benchmark_summary.md
-            echo "" >> benchmark_summary.md
-          fi
-        done
-
-        cat benchmark_summary.md
+        echo "Summary created by merge script:"
+        cat merged/benchmark_summary.md || echo "(no summary file found)"
 
     - name: Upload merged results
       uses: actions/upload-artifact@v4
       with:
         name: benchmark-results-merged
         path: |
-          merged/benchmark_results_merged.txt
+          merged/benchmark_results_merged.json
           merged/benchmark_summary.md
 
     - name: Add to Job Summary
       if: always()
       run: |
-        echo "# Combined Benchmark Results (All Architectures)" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo '```' >> $GITHUB_STEP_SUMMARY
-        cat merged/benchmark_results_merged.txt >> $GITHUB_STEP_SUMMARY
-        echo '```' >> $GITHUB_STEP_SUMMARY
+        cat merged/benchmark_summary.md >> $GITHUB_STEP_SUMMARY
 
   push-results:
     needs: merge-results
@@ -175,8 +146,8 @@ jobs:
       uses: benchmark-action/github-action-benchmark@v1
       with:
         name: C++ Benchmark
-        tool: 'catch2'
-        output-file-path: artifacts/benchmark_results_merged.txt
+        tool: 'google-benchmark'
+        output-file-path: artifacts/benchmark_results_merged.json
         gh-pages-branch: gh-pages
         benchmark-data-dir-path: dev/bench
         auto-push: true

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -74,8 +74,6 @@ jobs:
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-        -DCMAKE_CXX_STANDARD=11
-        -DCMAKE_CXX_STANDARD_REQUIRED=True
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         ${{ matrix.cmake_flags }}
         -S ${{ github.workspace }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,46 +18,48 @@ jobs:
 
     strategy:
       fail-fast: false
-
-      # Set up a matrix to run the following configurations:
-      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
-      # 2. <Linux x64, Release, latest GCC compiler toolchain on the default runner image, default generator>
-      # 3. <Linux x64, Release, latest Clang compiler toolchain on the default runner image, default generator>
-      # 4. <Linux ARM64, Release, GCC compiler on ARM runner>
-      # 5. <Linux ARM64, Release, Clang compiler on ARM runner>
-      # 6. <Linux ARM32, Release, cross-compiled with GCC on ARM runner>
       matrix:
-        os:
-          - ubuntu-latest
-          - ubuntu-24.04-arm
-          - windows-latest
-        cpp_compiler:
-          - g++
-          - clang++
-          - cl
-        build_type:
-          - Release
-        cmake_flags: [""]
         include:
+          # ubuntu-latest with GCC (coverage build)
+          - os: ubuntu-latest
+            cpp_compiler: g++
+            build_type: Release
+            cmake_flags: "-DCODE_COVERAGE=ON"
+          # ubuntu-latest with GCC (no coverage)
+          - os: ubuntu-latest
+            cpp_compiler: g++
+            build_type: Release
+            cmake_flags: ""
+          # ubuntu-latest with Clang
+          - os: ubuntu-latest
+            cpp_compiler: clang++
+            build_type: Release
+            cmake_flags: ""
+          # ubuntu-24.04-arm with GCC (native ARM64)
+          - os: ubuntu-24.04-arm
+            cpp_compiler: g++
+            build_type: Release
+            cmake_flags: ""
+          # ubuntu-24.04-arm with Clang (native ARM64)
+          - os: ubuntu-24.04-arm
+            cpp_compiler: clang++
+            build_type: Release
+            cmake_flags: ""
+          # ubuntu-24.04-arm with ARM32 cross-compile
           - os: ubuntu-24.04-arm
             cpp_compiler: arm-linux-gnueabihf-g++
             build_type: Release
             cmake_flags: "-DCMAKE_CROSSCOMPILING_EMULATOR=qemu-arm"
-        exclude:
+          # windows-latest with MSVC
           - os: windows-latest
-            cpp_compiler: g++
-          - os: windows-latest
-            cpp_compiler: clang++
-          - os: ubuntu-latest
             cpp_compiler: cl
-          - os: ubuntu-24.04-arm
-            cpp_compiler: cl
+            build_type: Release
+            cmake_flags: ""
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Set reusable strings
-      # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
       id: strings
       shell: bash
       run: |
@@ -71,17 +73,13 @@ jobs:
         sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf qemu-user libc6-armhf-cross libstdc++6-armhf-cross
 
     - name: Install gcovr
-      if: matrix.cpp_compiler == 'g++' && matrix.os == 'ubuntu-latest'
+      if: matrix.cmake_flags == '-DCODE_COVERAGE=ON'
       run: sudo apt-get install -y gcovr
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-        -DCMAKE_CXX_STANDARD=11
-        -DCMAKE_CXX_STANDARD_REQUIRED=True
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         ${{ matrix.cmake_flags }}
         -S ${{ github.workspace }}
@@ -95,11 +93,11 @@ jobs:
         QEMU_LD_PREFIX: ${{ matrix.cpp_compiler == 'arm-linux-gnueabihf-g++' && '/usr/arm-linux-gnueabihf' || '' }}
 
     - name: Generate code coverage
-      if: matrix.cpp_compiler == 'g++' && matrix.os == 'ubuntu-latest'
+      if: matrix.cmake_flags == '-DCODE_COVERAGE=ON'
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }} --target coverage
 
     - name: Publish to codecov
-      if: matrix.cpp_compiler == 'g++' && matrix.os == 'ubuntu-latest'
+      if: matrix.cmake_flags == '-DCODE_COVERAGE=ON'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -108,7 +106,7 @@ jobs:
         files: ${{ steps.strings.outputs.build-output-dir }}/coverage.xml
 
     - name: Upload Coverage Report
-      if: matrix.cpp_compiler == 'g++' && matrix.os == 'ubuntu-latest'
+      if: matrix.cmake_flags == '-DCODE_COVERAGE=ON'
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,30 +7,20 @@ enable_testing()
 include(FetchContent)
 include(CTest)
 
-# Fetch Catch2
-FetchContent_Declare(
-  Catch2
-  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG v3.8.0
-)
-FetchContent_MakeAvailable(Catch2)
-
 # Find clang-tidy and clang-format
 find_program(CLANG_TIDY_EXE NAMES clang-tidy)
 find_program(CLANG_FORMAT_EXE NAMES clang-format)
 
 # Set variables
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-	add_compile_options(-pedantic -Werror -Wall -Wextra -Wconversion -Wshadow -Wunused -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wuseless-cast -Wdouble-promotion)
+	set(PROJECT_COMPILE_OPTIONS -pedantic -Werror -Wall -Wextra -Wconversion -Wshadow -Wunused -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wuseless-cast -Wdouble-promotion)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  add_compile_options(-Werror -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-c++-compat -Wno-padded)
+  set(PROJECT_COMPILE_OPTIONS -Werror -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-c++-compat -Wno-padded)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  add_compile_options(/W4 /WX)
+  set(PROJECT_COMPILE_OPTIONS /W4 /WX)
 endif()
 
 # Include directories
@@ -61,45 +51,4 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     if(ENABLE_SANITIZERS)
         add_compile_options(-fsanitize=address,undefined)
     endif()
-endif()
-
-# Add gcovr target
-if(CODE_COVERAGE)
-  find_program(GCOVR_EXE NAMES gcovr)
-  if(GCOVR_EXE)
-    # Common gcovr args
-    set(GCOVR_FILTER_ARGS --filter ${CMAKE_SOURCE_DIR}/include/ --exclude-throw-branches)
-    set(GCOVR_GCOV_OPTION "")
-
-    # For Clang, prefer using llvm-cov as the gcov wrapper
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-      find_program(LLVM_COV_EXE NAMES llvm-cov)
-      if(LLVM_COV_EXE)
-        set(GCOVR_GCOV_OPTION --gcov-executable "${LLVM_COV_EXE} gcov")
-      else()
-        message(WARNING "llvm-cov not found! Coverage report will not be generated for Clang.")
-        set(SKIP_COVERAGE TRUE)
-      endif()
-    endif()
-
-    if(NOT SKIP_COVERAGE)
-      add_custom_target(
-        coverage-html
-        COMMAND ${GCOVR_EXE} -r ${CMAKE_SOURCE_DIR} ${GCOVR_GCOV_OPTION} ${GCOVR_FILTER_ARGS} --html --html-details -o coverage.html
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        COMMENT "Generating code coverage HTML report with gcovr for include folder only"
-      )
-      add_custom_target(
-        coverage-xml
-        COMMAND ${GCOVR_EXE} -r ${CMAKE_SOURCE_DIR} ${GCOVR_GCOV_OPTION} ${GCOVR_FILTER_ARGS} --xml-pretty -o coverage.xml
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        COMMENT "Generating code coverage XML report with gcovr for include folder only"
-      )
-      add_custom_target(
-        coverage
-        DEPENDS coverage-html coverage-xml
-        COMMENT "Aggregate target to generate all coverage reports"
-      )
-    endif()
-  endif()
 endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,10 +1,38 @@
+# Use C++23 for benchmarks and Google Benchmark
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Fetch Google Benchmark if not already available
+if(NOT TARGET benchmark::benchmark)
+  FetchContent_Declare(
+    benchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG v1.9.1
+  )
+  set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+  set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
+  set(HAVE_STD_REGEX ON CACHE BOOL "" FORCE)
+  set(RUN_HAVE_STD_REGEX 0 CACHE STRING "" FORCE)
+  FetchContent_MakeAvailable(benchmark)
+endif()
+
 file(GLOB_RECURSE ALL_BENCH_SOURCES "${CMAKE_SOURCE_DIR}/benchmarks/*.cpp")
 
 # Add executables
 add_executable(ZipViewBenchmark ${ALL_BENCH_SOURCES})
 
-# Set C++ standard for each target
-set_target_properties(ZipViewBenchmark PROPERTIES CXX_STANDARD 23)
+# Apply project warning flags to our benchmark code, but exclude some that conflict with Google Benchmark
+target_compile_options(ZipViewBenchmark PRIVATE ${PROJECT_COMPILE_OPTIONS})
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  # Disable specific warnings that Google Benchmark triggers
+  target_compile_options(ZipViewBenchmark PRIVATE
+    -Wno-global-constructors
+    -Wno-weak-vtables
+    -Wno-exit-time-destructors
+    -Wno-switch-default
+  )
+endif()
 
 # Link libraries
-target_link_libraries(ZipViewBenchmark PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(ZipViewBenchmark PRIVATE benchmark::benchmark benchmark::benchmark_main)

--- a/benchmarks/algo.cpp
+++ b/benchmarks/algo.cpp
@@ -1,12 +1,4 @@
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#endif
-#include <catch2/benchmark/catch_benchmark.hpp>
-#include <catch2/catch_test_macros.hpp>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include <benchmark/benchmark.h>
 
 #include "zip_view.hpp"
 #include <algorithm>
@@ -14,122 +6,70 @@
 #include <ranges>
 #include <vector>
 
-TEST_CASE("Benchmark ZipView Accumulate", "[algo]")
+static void BM_StdZipWithSort(benchmark::State& state)
 {
-  std::vector<int> v1(1000000);
-  auto             zip_ref = std::ranges::views::zip(v1);
-  auto             zip_sut = gst::ranges::views::zip(v1);
-
-  BENCHMARK("std zip accumulate")
+  for (auto _ : state)
   {
-    return std::accumulate(
-      zip_ref.begin(), zip_ref.end(), 0, [](auto acc, auto t) { return acc + std::get<0>(t); });
-  };
+    state.PauseTiming();
+    std::vector<int>  v1(10000);
+    std::vector<char> v2(10000);
+    std::iota(v1.begin(), v1.end(), 0);
+    std::iota(v2.begin(), v2.end(), 0);
+    auto zip = std::ranges::views::zip(v1, v2);
+    state.ResumeTiming();
 
-  BENCHMARK("gst zip accumulate")
-  {
-    return std::accumulate(
-      zip_sut.begin(), zip_sut.end(), 0, [](auto acc, auto t) { return acc + std::get<0>(t); });
-  };
+    std::ranges::sort(zip,
+                      [](auto const& a, auto const& b) { return std::get<0>(a) > std::get<0>(b); });
+    benchmark::DoNotOptimize(v1.data());
+  }
 }
+BENCHMARK(BM_StdZipWithSort);
 
-TEST_CASE("Benchmark ZipView Transform", "[algo]")
+static void BM_GstZipWithSort(benchmark::State& state)
 {
-  std::vector<int> v1(1000000);
-  std::vector<int> v2(v1.size());
-  auto             zip_ref  = std::ranges::views::zip(v1);
-  auto             zip_sut  = gst::ranges::views::zip(v1);
-  auto const       doubling = [](auto t) { return std::get<0>(t) * 2; };
-
-  BENCHMARK("std zip transform")
+  for (auto _ : state)
   {
-    std::transform(zip_ref.begin(), zip_ref.end(), v2.begin(), doubling);
-    return v2;
-  };
+    state.PauseTiming();
+    std::vector<int>  v1(10000);
+    std::vector<char> v2(10000);
+    std::iota(v1.begin(), v1.end(), 0);
+    std::iota(v2.begin(), v2.end(), 0);
+    auto zip = gst::ranges::views::zip(v1, v2);
+    state.ResumeTiming();
 
-  BENCHMARK("gst zip transform")
-  {
-    std::transform(zip_sut.begin(), zip_sut.end(), v2.begin(), doubling);
-    return v2;
-  };
+    std::ranges::sort(zip,
+                      [](auto const& a, auto const& b) { return std::get<0>(a) > std::get<0>(b); });
+    benchmark::DoNotOptimize(v1.data());
+  }
 }
+BENCHMARK(BM_GstZipWithSort);
 
-TEST_CASE("Benchmark ZipView Sort", "[algo]")
+static void BM_StdZipWithFind(benchmark::State& state)
 {
-  BENCHMARK("std zip + sort")
-  {
-    std::vector<int> v1{5, 2, 8, 1, 9, 3, 7, 4, 6};
-    std::vector<int> v2{50, 20, 80, 10, 90, 30, 70, 40, 60};
-    auto             zip_ref = std::ranges::views::zip(v1, v2);
-
-    // Need to use ranges algorithms or create a temporary container
-    std::vector<std::tuple<int, int>> temp;
-    temp.reserve(v1.size());
-    for (auto t : zip_ref) { temp.push_back(std::make_tuple(std::get<0>(t), std::get<1>(t))); }
-    std::sort(temp.begin(), temp.end());
-    return temp;
-  };
-
-  BENCHMARK("gst zip + sort")
-  {
-    std::vector<int> v1{5, 2, 8, 1, 9, 3, 7, 4, 6};
-    std::vector<int> v2{50, 20, 80, 10, 90, 30, 70, 40, 60};
-    auto             zip_sut = gst::ranges::views::zip(v1, v2);
-    std::sort(zip_sut.begin(),
-              zip_sut.end(),
-              [](auto const& a, auto const& b) { return std::get<0>(a) < std::get<0>(b); });
-    return v1;
-  };
-}
-
-TEST_CASE("Benchmark ZipView Find", "[algo]")
-{
-  std::vector<int> v1(100000);
-  std::vector<int> v2(100000);
-
-  // Fill with values
+  std::vector<int>  v1(100000);
+  std::vector<char> v2(100000);
   std::iota(v1.begin(), v1.end(), 0);
-  std::iota(v2.begin(), v2.end(), 100000);
+  auto zip = std::ranges::views::zip(v1, v2);
 
-  auto zip_ref = std::ranges::views::zip(v1, v2);
-  auto zip_sut = gst::ranges::views::zip(v1, v2);
-
-  BENCHMARK("std zip + find_if")
+  for (auto _ : state)
   {
-    auto it = std::find_if(std::ranges::begin(zip_ref),
-                           std::ranges::end(zip_ref),
-                           [](auto const& t) { return std::get<0>(t) == 75000; });
-    return it != std::ranges::end(zip_ref);
-  };
-
-  BENCHMARK("gst zip + find_if")
-  {
-    auto it = std::find_if(
-      zip_sut.begin(), zip_sut.end(), [](auto const& t) { return std::get<0>(t) == 75000; });
-    return it != zip_sut.end();
-  };
+    auto it = std::ranges::find_if(zip, [](auto const& t) { return std::get<0>(t) == 50000; });
+    benchmark::DoNotOptimize(it);
+  }
 }
+BENCHMARK(BM_StdZipWithFind);
 
-TEST_CASE("Benchmark ZipView Copy", "[algo]")
+static void BM_GstZipWithFind(benchmark::State& state)
 {
-  std::vector<int> v1(100000);
-  std::vector<int> v2(100000);
-  std::vector<int> out1(100000);
-  std::vector<int> out2(100000);
+  std::vector<int>  v1(100000);
+  std::vector<char> v2(100000);
+  std::iota(v1.begin(), v1.end(), 0);
+  auto zip = gst::ranges::views::zip(v1, v2);
 
-  auto zip_ref = std::ranges::views::zip(v1, v2);
-  auto zip_sut = gst::ranges::views::zip(v1, v2);
-  auto zip_out = gst::ranges::views::zip(out1, out2);
-
-  BENCHMARK("std zip + copy")
+  for (auto _ : state)
   {
-    std::copy(std::ranges::begin(zip_ref), std::ranges::end(zip_ref), zip_out.begin());
-    return out1;
-  };
-
-  BENCHMARK("gst zip + copy")
-  {
-    std::copy(zip_sut.begin(), zip_sut.end(), zip_out.begin());
-    return out1;
-  };
+    auto it = std::ranges::find_if(zip, [](auto const& t) { return std::get<0>(t) == 50000; });
+    benchmark::DoNotOptimize(it);
+  }
 }
+BENCHMARK(BM_GstZipWithFind);

--- a/benchmarks/ctor.cpp
+++ b/benchmarks/ctor.cpp
@@ -1,28 +1,61 @@
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#endif
-#include <catch2/benchmark/catch_benchmark.hpp>
-#include <catch2/catch_test_macros.hpp>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include <benchmark/benchmark.h>
 
 #include "zip_view.hpp"
 #include <ranges>
 #include <vector>
 
-TEST_CASE("Benchmark ZipView Constructor", "[ctor]")
+static void BM_StdZipConstruction(benchmark::State& state)
 {
-  BENCHMARK("std zip construct")
-  {
-    std::vector<int> v1(1000000);
-    return std::ranges::views::zip(v1);
-  };
+  std::vector<int>  v1(1000);
+  std::vector<char> v2(1000);
 
-  BENCHMARK("gst zip construct")
+  for (auto _ : state)
   {
-    std::vector<int> v1(1000000);
-    return gst::ranges::views::zip(v1);
-  };
+    auto zip = std::ranges::views::zip(v1, v2);
+    benchmark::DoNotOptimize(zip);
+  }
 }
+BENCHMARK(BM_StdZipConstruction);
+
+static void BM_GstZipConstruction(benchmark::State& state)
+{
+  std::vector<int>  v1(1000);
+  std::vector<char> v2(1000);
+
+  for (auto _ : state)
+  {
+    auto zip = gst::ranges::views::zip(v1, v2);
+    benchmark::DoNotOptimize(zip);
+  }
+}
+BENCHMARK(BM_GstZipConstruction);
+
+static void BM_StdZipConstruction4Containers(benchmark::State& state)
+{
+  std::vector<int>    v1(1000);
+  std::vector<double> v2(1000);
+  std::vector<char>   v3(1000);
+  std::vector<float>  v4(1000);
+
+  for (auto _ : state)
+  {
+    auto zip = std::ranges::views::zip(v1, v2, v3, v4);
+    benchmark::DoNotOptimize(zip);
+  }
+}
+BENCHMARK(BM_StdZipConstruction4Containers);
+
+static void BM_GstZipConstruction4Containers(benchmark::State& state)
+{
+  std::vector<int>    v1(1000);
+  std::vector<double> v2(1000);
+  std::vector<char>   v3(1000);
+  std::vector<float>  v4(1000);
+
+  for (auto _ : state)
+  {
+    auto zip = gst::ranges::views::zip(v1, v2, v3, v4);
+    benchmark::DoNotOptimize(zip);
+  }
+}
+BENCHMARK(BM_GstZipConstruction4Containers);

--- a/benchmarks/iter.cpp
+++ b/benchmarks/iter.cpp
@@ -1,213 +1,65 @@
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#endif
-#include <catch2/benchmark/catch_benchmark.hpp>
-#include <catch2/catch_test_macros.hpp>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include <benchmark/benchmark.h>
 
 #include "zip_view.hpp"
-#include <algorithm>
-#include <list>
-#include <numeric>
 #include <ranges>
 #include <vector>
 
-TEST_CASE("Benchmark ZipView Bidirectional Same Sizes", "[bidirectional][same_sizes]")
+static void BM_StdZipIteratorIncrement(benchmark::State& state)
 {
-  std::list<int> l1(100000);
-  std::list<int> l2(100000);
+  std::vector<int>  v1(100000);
+  std::vector<char> v2(100000);
+  auto              zip_ref = std::ranges::views::zip(v1, v2);
 
-  // Fill with values
-  std::iota(l1.begin(), l1.end(), 0);
-  std::iota(l2.begin(), l2.end(), 100000);
-
-  auto zip_ref = std::ranges::views::zip(l1, l2);
-  auto zip_sut = gst::ranges::views::zip(l1, l2);
-
-  BENCHMARK("std zip bidi same sizes")
+  for (auto _ : state)
   {
-    int sum = 0;
-    for (auto t : zip_ref) { sum += std::get<0>(t) + std::get<1>(t); }
-    return sum;
-  };
-
-  BENCHMARK("gst zip bidi same sizes")
-  {
-    int sum = 0;
-    for (auto t : zip_sut) { sum += std::get<0>(t) + std::get<1>(t); }
-    return sum;
-  };
+    auto it = zip_ref.begin();
+    while (it != zip_ref.end()) { ++it; }
+    benchmark::DoNotOptimize(it);
+  }
 }
+BENCHMARK(BM_StdZipIteratorIncrement);
 
-TEST_CASE("Benchmark ZipView Forward Same Sizes", "[forward][same_sizes]")
+static void BM_GstZipIteratorIncrement(benchmark::State& state)
 {
-  std::vector<int> v1(100000);
-  std::vector<int> v2(100000);
+  std::vector<int>  v1(100000);
+  std::vector<char> v2(100000);
+  auto              zip_sut = gst::ranges::views::zip(v1, v2);
 
-  std::iota(v1.begin(), v1.end(), 0);
-  std::iota(v2.begin(), v2.end(), 100000);
-
-  auto zip_ref = std::ranges::views::zip(v1, v2);
-  auto zip_sut = gst::ranges::views::zip(v1, v2);
-
-  BENCHMARK("std zip fwd same sizes")
+  for (auto _ : state)
   {
-    int  sum = 0;
+    auto it = zip_sut.begin();
+    while (it != zip_sut.end()) { ++it; }
+    benchmark::DoNotOptimize(it);
+  }
+}
+BENCHMARK(BM_GstZipIteratorIncrement);
+
+static void BM_StdZipIteratorRandomAccess(benchmark::State& state)
+{
+  std::vector<int>  v1(100000);
+  std::vector<char> v2(100000);
+  auto              zip_ref = std::ranges::views::zip(v1, v2);
+
+  for (auto _ : state)
+  {
     auto it  = zip_ref.begin();
-    while (it != zip_ref.end())
-    {
-      sum += std::get<0>(*it) + std::get<1>(*it);
-      ++it;
-    }
-    return sum;
-  };
+    auto val = it[50000];
+    benchmark::DoNotOptimize(val);
+  }
+}
+BENCHMARK(BM_StdZipIteratorRandomAccess);
 
-  BENCHMARK("gst zip fwd same sizes")
+static void BM_GstZipIteratorRandomAccess(benchmark::State& state)
+{
+  std::vector<int>  v1(100000);
+  std::vector<char> v2(100000);
+  auto              zip_sut = gst::ranges::views::zip(v1, v2);
+
+  for (auto _ : state)
   {
-    int  sum = 0;
     auto it  = zip_sut.begin();
-    while (it != zip_sut.end())
-    {
-      sum += std::get<0>(*it) + std::get<1>(*it);
-      ++it;
-    }
-    return sum;
-  };
+    auto val = it[50000];
+    benchmark::DoNotOptimize(val);
+  }
 }
-
-TEST_CASE("Benchmark ZipView Reverse Same Sizes", "[reverse][same_sizes]")
-{
-  std::vector<int> v1(100000);
-  std::vector<int> v2(100000);
-
-  std::iota(v1.begin(), v1.end(), 0);
-  std::iota(v2.begin(), v2.end(), 100000);
-
-  auto zip_ref = std::ranges::views::zip(v1, v2);
-  auto zip_sut = gst::ranges::views::zip(v1, v2);
-
-  BENCHMARK("std zip rev same sizes")
-  {
-    int  sum = 0;
-    auto it  = zip_ref.end();
-    while (it != zip_ref.begin())
-    {
-      --it;
-      sum += std::get<0>(*it) + std::get<1>(*it);
-    }
-    return sum;
-  };
-
-  BENCHMARK("gst zip rev same sizes")
-  {
-    int  sum = 0;
-    auto it  = zip_sut.end();
-    while (it != zip_sut.begin())
-    {
-      --it;
-      sum += std::get<0>(*it) + std::get<1>(*it);
-    }
-    return sum;
-  };
-}
-
-TEST_CASE("Benchmark ZipView Bidirectional Different Sizes", "[bidirectional][different_sizes]")
-{
-  std::list<int> l1(100000);
-  std::list<int> l2(100001); // Different size
-
-  std::iota(l1.begin(), l1.end(), 0);
-  std::iota(l2.begin(), l2.end(), 100000);
-
-  auto zip_ref = std::ranges::views::zip(l1, l2);
-  auto zip_sut = gst::ranges::views::zip(l1, l2);
-
-  BENCHMARK("std zip bidi diff sizes")
-  {
-    int sum = 0;
-    for (auto t : zip_ref) { sum += std::get<0>(t) + std::get<1>(t); }
-    return sum;
-  };
-
-  BENCHMARK("gst zip bidi diff sizes")
-  {
-    int sum = 0;
-    for (auto t : zip_sut) { sum += std::get<0>(t) + std::get<1>(t); }
-    return sum;
-  };
-}
-
-TEST_CASE("Benchmark ZipView Forward Different Sizes", "[forward][different_sizes]")
-{
-  std::vector<int> v1(100000);
-  std::vector<int> v2(100001); // Different size
-
-  std::iota(v1.begin(), v1.end(), 0);
-  std::iota(v2.begin(), v2.end(), 100000);
-
-  auto zip_ref = std::ranges::views::zip(v1, v2);
-  auto zip_sut = gst::ranges::views::zip(v1, v2);
-
-  BENCHMARK("std zip fwd diff sizes")
-  {
-    int  sum = 0;
-    auto it  = zip_ref.begin();
-    while (it != zip_ref.end())
-    {
-      sum += std::get<0>(*it) + std::get<1>(*it);
-      ++it;
-    }
-    return sum;
-  };
-
-  BENCHMARK("gst zip fwd diff sizes")
-  {
-    int  sum = 0;
-    auto it  = zip_sut.begin();
-    while (it != zip_sut.end())
-    {
-      sum += std::get<0>(*it) + std::get<1>(*it);
-      ++it;
-    }
-    return sum;
-  };
-}
-
-TEST_CASE("Benchmark ZipView Reverse Different Sizes", "[reverse][different_sizes]")
-{
-  std::vector<int> v1(100000);
-  std::vector<int> v2(100001); // Different size
-
-  std::iota(v1.begin(), v1.end(), 0);
-  std::iota(v2.begin(), v2.end(), 100000);
-
-  auto zip_ref = std::ranges::views::zip(v1, v2);
-  auto zip_sut = gst::ranges::views::zip(v1, v2);
-
-  BENCHMARK("std zip rev diff sizes")
-  {
-    int  sum = 0;
-    auto it  = zip_ref.end();
-    while (it != zip_ref.begin())
-    {
-      --it;
-      sum += std::get<0>(*it) + std::get<1>(*it);
-    }
-    return sum;
-  };
-
-  BENCHMARK("gst zip rev diff sizes")
-  {
-    int  sum = 0;
-    auto it  = zip_sut.end();
-    while (it != zip_sut.begin())
-    {
-      --it;
-      sum += std::get<0>(*it) + std::get<1>(*it);
-    }
-    return sum;
-  };
-}
+BENCHMARK(BM_GstZipIteratorRandomAccess);

--- a/benchmarks/loop.cpp
+++ b/benchmarks/loop.cpp
@@ -1,49 +1,46 @@
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#endif
-#include <catch2/benchmark/catch_benchmark.hpp>
-#include <catch2/catch_test_macros.hpp>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include <benchmark/benchmark.h>
 
 #include "zip_view.hpp"
 #include <ranges>
 #include <vector>
 
-TEST_CASE("Benchmark ZipView Iteration", "[loop]")
+static void BM_StdZipIterate(benchmark::State& state)
 {
   std::vector<int> v1(1000000);
   auto             zip_ref = std::ranges::views::zip(v1);
-  auto             zip_sut = gst::ranges::views::zip(v1);
 
-  BENCHMARK("std zip iterate")
+  for (auto _ : state)
   {
     int sum = 0;
     for (auto t : zip_ref) { sum += std::get<0>(t); }
-    return sum;
-  };
+    benchmark::DoNotOptimize(sum);
+  }
+}
+BENCHMARK(BM_StdZipIterate);
 
-  BENCHMARK("gst zip iterate")
+static void BM_GstZipIterate(benchmark::State& state)
+{
+  std::vector<int> v1(1000000);
+  auto             zip_sut = gst::ranges::views::zip(v1);
+
+  for (auto _ : state)
   {
     int sum = 0;
     for (auto t : zip_sut) { sum += std::get<0>(t); }
-    return sum;
-  };
+    benchmark::DoNotOptimize(sum);
+  }
 }
+BENCHMARK(BM_GstZipIterate);
 
-TEST_CASE("Benchmark ZipView Iteration Multiple Containers", "[loop]")
+static void BM_StdZipIterate4Ranges(benchmark::State& state)
 {
   std::vector<int>    v1(100000);
   std::vector<double> v2(100000);
   std::vector<char>   v3(100000);
   std::vector<float>  v4(100000);
+  auto                zip_ref = std::ranges::views::zip(v1, v2, v3, v4);
 
-  auto zip_ref = std::ranges::views::zip(v1, v2, v3, v4);
-  auto zip_sut = gst::ranges::views::zip(v1, v2, v3, v4);
-
-  BENCHMARK("std zip iterate 4 ranges")
+  for (auto _ : state)
   {
     int sum = 0;
     for (auto t : zip_ref)
@@ -51,10 +48,20 @@ TEST_CASE("Benchmark ZipView Iteration Multiple Containers", "[loop]")
       sum += static_cast<int>(std::get<0>(t)) + static_cast<int>(std::get<1>(t)) +
              static_cast<int>(std::get<2>(t)) + static_cast<int>(std::get<3>(t));
     }
-    return sum;
-  };
+    benchmark::DoNotOptimize(sum);
+  }
+}
+BENCHMARK(BM_StdZipIterate4Ranges);
 
-  BENCHMARK("gst zip iterate 4 ranges")
+static void BM_GstZipIterate4Ranges(benchmark::State& state)
+{
+  std::vector<int>    v1(100000);
+  std::vector<double> v2(100000);
+  std::vector<char>   v3(100000);
+  std::vector<float>  v4(100000);
+  auto                zip_sut = gst::ranges::views::zip(v1, v2, v3, v4);
+
+  for (auto _ : state)
   {
     int sum = 0;
     for (auto t : zip_sut)
@@ -62,6 +69,7 @@ TEST_CASE("Benchmark ZipView Iteration Multiple Containers", "[loop]")
       sum += static_cast<int>(std::get<0>(t)) + static_cast<int>(std::get<1>(t)) +
              static_cast<int>(std::get<2>(t)) + static_cast<int>(std::get<3>(t));
     }
-    return sum;
-  };
+    benchmark::DoNotOptimize(sum);
+  }
 }
+BENCHMARK(BM_GstZipIterate4Ranges);

--- a/benchmarks/temp.cpp
+++ b/benchmarks/temp.cpp
@@ -1,147 +1,41 @@
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#endif
-#include <catch2/benchmark/catch_benchmark.hpp>
-#include <catch2/catch_test_macros.hpp>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include <benchmark/benchmark.h>
 
 #include "zip_view.hpp"
-
-#include <algorithm>
-#include <numeric>
+#include <array>
 #include <ranges>
-#include <string>
-#include <tuple>
 #include <vector>
 
 namespace
 {
-// Small helper to create a non-trivial temporary.
-// Returning by value ensures we exercise the "in-place temporary" case when used inside
-// views::zip(...).
-std::vector<int> make_iota_vec(std::size_t n, int start)
+template <std::size_t N, int start = 0>
+std::array<int32_t, N> make_iota_vec()
 {
-  std::vector<int> v(n);
-  std::iota(v.begin(), v.end(), start);
-  return v;
+  std::array<int32_t, N> arr;
+  std::ranges::iota(arr, start);
+  return arr;
 }
+
+constexpr std::size_t N = 1'000'000;
 } // namespace
 
-TEST_CASE("Benchmark ZipView In-place Temporary In Loop", "[temp][loop]")
+static void BM_StdZipWithTemporaries(benchmark::State& state)
 {
-  constexpr std::size_t N = 1'000'000;
-
-  BENCHMARK("std zip loop with temporary")
+  for (auto _ : state)
   {
-    long long sum = 0;
-    for (auto t : std::ranges::views::zip(make_iota_vec(N, 0))) { sum += std::get<0>(t); }
-    return sum;
-  };
-
-  BENCHMARK("gst zip loop with temporary")
-  {
-    long long sum = 0;
-    for (auto t : gst::ranges::views::zip(make_iota_vec(N, 0))) { sum += std::get<0>(t); }
-    return sum;
-  };
+    int sum = 0;
+    for (auto t : std::ranges::views::zip(make_iota_vec<N, 0>())) { sum += std::get<0>(t); }
+    benchmark::DoNotOptimize(sum);
+  }
 }
+BENCHMARK(BM_StdZipWithTemporaries);
 
-TEST_CASE("Benchmark ZipView In-place Temporaries Multiple Ranges In Loop", "[temp][loop]")
+static void BM_GstZipWithTemporaries(benchmark::State& state)
 {
-  constexpr std::size_t N = 250'000;
-
-  BENCHMARK("std zip loop 2 temporaries")
+  for (auto _ : state)
   {
-    long long sum = 0;
-    for (auto t : std::ranges::views::zip(make_iota_vec(N, 0), make_iota_vec(N, 1)))
-    {
-      sum += std::get<0>(t) + std::get<1>(t);
-    }
-    return sum;
-  };
-
-  BENCHMARK("gst zip loop 2 temporaries")
-  {
-    long long sum = 0;
-    for (auto t : gst::ranges::views::zip(make_iota_vec(N, 0), make_iota_vec(N, 1)))
-    {
-      sum += std::get<0>(t) + std::get<1>(t);
-    }
-    return sum;
-  };
+    int sum = 0;
+    for (auto t : gst::ranges::views::zip(make_iota_vec<N, 0>())) { sum += std::get<0>(t); }
+    benchmark::DoNotOptimize(sum);
+  }
 }
-
-TEST_CASE("Benchmark ZipView In-place Temporary With std::ranges Algorithms", "[temp][algo]")
-{
-  constexpr std::size_t N = 1'000'000;
-
-  BENCHMARK("std zip + ranges::for_each (temporary)")
-  {
-    long long sum = 0;
-    std::ranges::for_each(std::ranges::views::zip(make_iota_vec(N, 0)),
-                          [&](auto t) { sum += std::get<0>(t); });
-    return sum;
-  };
-
-  BENCHMARK("gst zip + ranges::for_each (temporary)")
-  {
-    long long sum = 0;
-    std::ranges::for_each(gst::ranges::views::zip(make_iota_vec(N, 0)),
-                          [&](auto t) { sum += std::get<0>(t); });
-    return sum;
-  };
-
-  BENCHMARK("std zip + ranges::fold_left (temporary)")
-  {
-    return std::ranges::fold_left(std::ranges::views::zip(make_iota_vec(N, 0)),
-                                  0LL,
-                                  [](long long acc, auto t) { return acc + std::get<0>(t); });
-  };
-
-  BENCHMARK("gst zip + ranges::fold_left (temporary)")
-  {
-    return std::ranges::fold_left(gst::ranges::views::zip(make_iota_vec(N, 0)),
-                                  0LL,
-                                  [](long long acc, auto t) { return acc + std::get<0>(t); });
-  };
-
-  BENCHMARK("std zip + ranges::count_if (temporary)")
-  {
-    return std::ranges::count_if(std::ranges::views::zip(make_iota_vec(N, 0)),
-                                 [](auto t) { return (std::get<0>(t) & 1) == 0; });
-  };
-
-  BENCHMARK("gst zip + ranges::count_if (temporary)")
-  {
-    return std::ranges::count_if(gst::ranges::views::zip(make_iota_vec(N, 0)),
-                                 [](auto t) { return (std::get<0>(t) & 1) == 0; });
-  };
-}
-
-TEST_CASE("Benchmark ZipView Temporary + ranges::copy", "[temp][algo]")
-{
-  constexpr std::size_t N = 500'000;
-
-  BENCHMARK("std zip + ranges::copy (temporary)")
-  {
-    auto             r = std::ranges::views::zip(make_iota_vec(N, 0));
-    std::vector<int> out(N);
-    auto             out_zip = gst::ranges::views::zip(out);
-
-    std::ranges::copy(r.begin(), r.end(), out_zip.begin());
-    return out;
-  };
-
-  BENCHMARK("gst zip + ranges::copy (temporary)")
-  {
-    auto             r = gst::ranges::views::zip(make_iota_vec(N, 0));
-    std::vector<int> out(N);
-    auto             out_zip = gst::ranges::views::zip(out);
-
-    std::ranges::copy(r.begin(), r.end(), out_zip.begin());
-    return out;
-  };
-}
+BENCHMARK(BM_GstZipWithTemporaries);

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,9 +1,9 @@
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 file(GLOB_RECURSE ALL_EXAMPLE_SOURCES "${CMAKE_SOURCE_DIR}/examples/*.cpp")
 
-# Add executables
 add_executable(ZipViewExamples ${ALL_EXAMPLE_SOURCES})
 
-# Set C++ standard for each target
-set_target_properties(ZipViewExamples PROPERTIES CXX_STANDARD 11
-                                                 CXX_STANDARD_REQUIRED YES
-                                                 CXX_EXTENSIONS NO)
+target_compile_options(ZipViewExamples PRIVATE ${PROJECT_COMPILE_OPTIONS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,68 @@
+# Fetch Catch2 if not already available
+if(NOT TARGET Catch2::Catch2WithMain)
+  FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.8.0
+  )
+  FetchContent_MakeAvailable(Catch2)
+endif()
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Code coverage option (disabled by default)
+option(CODE_COVERAGE "Enable code coverage" OFF)
+
+# Add gcovr target
+if(CODE_COVERAGE)
+  find_program(GCOVR_EXE NAMES gcovr)
+  if(GCOVR_EXE)
+    # Common gcovr args
+    set(GCOVR_FILTER_ARGS --filter ${CMAKE_SOURCE_DIR}/include/ --exclude-throw-branches)
+    set(GCOVR_GCOV_OPTION "")
+
+    # For Clang, prefer using llvm-cov as the gcov wrapper
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      find_program(LLVM_COV_EXE NAMES llvm-cov)
+      if(LLVM_COV_EXE)
+        set(GCOVR_GCOV_OPTION --gcov-executable "${LLVM_COV_EXE} gcov")
+      else()
+        message(WARNING "llvm-cov not found! Coverage report will not be generated for Clang.")
+        set(SKIP_COVERAGE TRUE)
+      endif()
+    endif()
+
+    if(NOT SKIP_COVERAGE)
+      add_custom_target(
+        coverage-html
+        COMMAND ${GCOVR_EXE} -r ${CMAKE_SOURCE_DIR} ${GCOVR_GCOV_OPTION} ${GCOVR_FILTER_ARGS} --html --html-details -o coverage.html
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMENT "Generating code coverage HTML report with gcovr for include folder only"
+      )
+      add_custom_target(
+        coverage-xml
+        COMMAND ${GCOVR_EXE} -r ${CMAKE_SOURCE_DIR} ${GCOVR_GCOV_OPTION} ${GCOVR_FILTER_ARGS} --xml-pretty -o coverage.xml
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMENT "Generating code coverage XML report with gcovr for include folder only"
+      )
+      add_custom_target(
+        coverage
+        DEPENDS coverage-html coverage-xml
+        COMMENT "Aggregate target to generate all coverage reports"
+      )
+    endif()
+  endif()
+endif()
+
 file(GLOB_RECURSE ALL_TEST_SOURCES "${CMAKE_SOURCE_DIR}/tests/*.cpp")
 
 # Add executables
 add_executable(ZipViewTests ${ALL_TEST_SOURCES})
 
-# Set C++ standard for each target
-set_target_properties(ZipViewTests PROPERTIES CXX_STANDARD 23)
+# Compile options
+target_compile_options(ZipViewTests PRIVATE ${PROJECT_COMPILE_OPTIONS})
 
 # Link libraries
 target_link_libraries(ZipViewTests PRIVATE Catch2::Catch2WithMain)
@@ -13,10 +71,7 @@ target_link_libraries(ZipViewTests PRIVATE Catch2::Catch2WithMain)
 add_test(NAME ZipViewTests COMMAND ZipViewTests)
 
 # Add coverage flags only for ZipViewTests
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  option(CODE_COVERAGE "Enable coverage reporting" ON)
-  if(CODE_COVERAGE)
-    target_compile_options(ZipViewTests PRIVATE --coverage -O0 -g)
-    target_link_options(ZipViewTests PRIVATE --coverage)
-  endif()
+if(CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_compile_options(ZipViewTests PRIVATE --coverage -O0 -g)
+  target_link_options(ZipViewTests PRIVATE --coverage)
 endif()


### PR DESCRIPTION
- Convert benchmarks to Google Benchmark (C++23)
- Add `merge_benchmarks.py`
- Emit per-arch JSON and upload artifacts in workflow
- Merge results and publish benchmark summary in Markdown format
- Make `CODE_COVERAGE` opt-in
- Move coverage targets to `CMakeLists.txt`
- Apply per-target compile options and update CMake files
- Update `copilot-instructions.md`