### PR TITLE
Fix nested zip views

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+# Codecov configuration - explicitly ignore test sources from coverage reports
+# See: https://docs.codecov.com/docs/codecov-yaml
+
+ignore:
+  - "tests/**"   # do not report coverage for test sources
+  - "build/**"   # optional: ignore build artifacts

--- a/benchmarks/nest.cpp
+++ b/benchmarks/nest.cpp
@@ -1,0 +1,444 @@
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+#endif
+#include <benchmark/benchmark.h>
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+#include "zip_view.hpp"
+#include <algorithm>
+#include <numeric>
+#include <ranges>
+#include <utility>
+#include <vector>
+
+template <typename... R>
+auto std_zip(R&&... r)
+{
+  return std::ranges::views::zip(std::forward<R>(r)...);
+}
+
+template <typename... R>
+auto gst_zip(R&&... r)
+{
+  return gst::ranges::views::zip(std::forward<R>(r)...);
+}
+
+// Converted Catch2 benchmarks -> Google Benchmark
+
+template <bool UseGst>
+static void BM_NestedZipIterate2x2_impl(benchmark::State& state)
+{
+  std::vector<int> v1(100000);
+  std::vector<int> v2(100000);
+  std::vector<int> v3(100000);
+  std::vector<int> v4(100000);
+
+  std::iota(v1.begin(), v1.end(), 0);
+  std::iota(v2.begin(), v2.end(), 100000);
+  std::iota(v3.begin(), v3.end(), 200000);
+  std::iota(v4.begin(), v4.end(), 300000);
+
+  auto make_zip = [](auto&&... args)
+  {
+    if constexpr (UseGst)
+      return gst_zip(std::forward<decltype(args)>(args)...);
+    else
+      return std_zip(std::forward<decltype(args)>(args)...);
+  };
+
+  auto zip1   = make_zip(v1, v2);
+  auto zip2   = make_zip(v3, v4);
+  auto nested = make_zip(zip1, zip2);
+
+  for (auto _ : state)
+  {
+    int sum = 0;
+    for (auto t : nested)
+    {
+      auto t0  = std::get<0>(t);
+      auto t1  = std::get<1>(t);
+      sum     += std::get<0>(t0) + std::get<1>(t0) + std::get<0>(t1) + std::get<1>(t1);
+    }
+    benchmark::DoNotOptimize(sum);
+  }
+}
+
+static void BM_StdNestedZipIterate2x2(benchmark::State& s)
+{
+  BM_NestedZipIterate2x2_impl<false>(s);
+}
+static void BM_GstNestedZipIterate2x2(benchmark::State& s) { BM_NestedZipIterate2x2_impl<true>(s); }
+
+BENCHMARK(BM_StdNestedZipIterate2x2);
+BENCHMARK(BM_GstNestedZipIterate2x2);
+
+template <bool UseGst>
+static void BM_NestedZipAccumulate_impl(benchmark::State& state)
+{
+  std::vector<int> v1(100000);
+  std::vector<int> v2(100000);
+  std::vector<int> v3(100000);
+  std::vector<int> v4(100000);
+
+  std::iota(v1.begin(), v1.end(), 0);
+  std::iota(v2.begin(), v2.end(), 100000);
+  std::iota(v3.begin(), v3.end(), 200000);
+  std::iota(v4.begin(), v4.end(), 300000);
+
+  auto make_zip = [](auto&&... args)
+  {
+    if constexpr (UseGst)
+      return gst_zip(std::forward<decltype(args)>(args)...);
+    else
+      return std_zip(std::forward<decltype(args)>(args)...);
+  };
+
+  auto zip1   = make_zip(v1, v2);
+  auto zip2   = make_zip(v3, v4);
+  auto nested = make_zip(zip1, zip2);
+
+  for (auto _ : state)
+  {
+    int res = std::accumulate(nested.begin(),
+                              nested.end(),
+                              0,
+                              [](auto acc, auto t)
+                              {
+                                auto t0 = std::get<0>(t);
+                                auto t1 = std::get<1>(t);
+                                return acc + std::get<0>(t0) + std::get<1>(t0) + std::get<0>(t1) +
+                                       std::get<1>(t1);
+                              });
+    benchmark::DoNotOptimize(res);
+  }
+}
+
+static void BM_StdNestedZipAccumulate(benchmark::State& s)
+{
+  BM_NestedZipAccumulate_impl<false>(s);
+}
+static void BM_GstNestedZipAccumulate(benchmark::State& s) { BM_NestedZipAccumulate_impl<true>(s); }
+
+BENCHMARK(BM_StdNestedZipAccumulate);
+BENCHMARK(BM_GstNestedZipAccumulate);
+
+template <bool UseGst>
+static void BM_NestedZipTransform_impl(benchmark::State& state)
+{
+  std::vector<int> v1(100000);
+  std::vector<int> v2(100000);
+  std::vector<int> v3(100000);
+  std::vector<int> v4(100000);
+  std::vector<int> out(100000);
+
+  std::iota(v1.begin(), v1.end(), 0);
+  std::iota(v2.begin(), v2.end(), 100000);
+  std::iota(v3.begin(), v3.end(), 200000);
+  std::iota(v4.begin(), v4.end(), 300000);
+
+  auto make_zip = [](auto&&... args)
+  {
+    if constexpr (UseGst)
+      return gst_zip(std::forward<decltype(args)>(args)...);
+    else
+      return std_zip(std::forward<decltype(args)>(args)...);
+  };
+
+  auto zip1   = make_zip(v1, v2);
+  auto zip2   = make_zip(v3, v4);
+  auto nested = make_zip(zip1, zip2);
+
+  for (auto _ : state)
+  {
+    std::transform(nested.begin(),
+                   nested.end(),
+                   out.begin(),
+                   [](auto t)
+                   {
+                     auto t0 = std::get<0>(t);
+                     auto t1 = std::get<1>(t);
+                     return std::get<0>(t0) + std::get<1>(t0) + std::get<0>(t1) + std::get<1>(t1);
+                   });
+    benchmark::DoNotOptimize(out.data());
+  }
+}
+
+static void BM_StdNestedZipTransform(benchmark::State& s) { BM_NestedZipTransform_impl<false>(s); }
+static void BM_GstNestedZipTransform(benchmark::State& s) { BM_NestedZipTransform_impl<true>(s); }
+
+BENCHMARK(BM_StdNestedZipTransform);
+BENCHMARK(BM_GstNestedZipTransform);
+
+template <bool UseGst>
+static void BM_NestedZipFindIf_impl(benchmark::State& state)
+{
+  std::vector<int> v1(100000);
+  std::vector<int> v2(100000);
+  std::vector<int> v3(100000);
+  std::vector<int> v4(100000);
+
+  std::iota(v1.begin(), v1.end(), 0);
+  std::iota(v2.begin(), v2.end(), 100000);
+  std::iota(v3.begin(), v3.end(), 200000);
+  std::iota(v4.begin(), v4.end(), 300000);
+
+  auto make_zip = [](auto&&... args)
+  {
+    if constexpr (UseGst)
+      return gst_zip(std::forward<decltype(args)>(args)...);
+    else
+      return std_zip(std::forward<decltype(args)>(args)...);
+  };
+
+  auto zip1   = make_zip(v1, v2);
+  auto zip2   = make_zip(v3, v4);
+  auto nested = make_zip(zip1, zip2);
+
+  for (auto _ : state)
+  {
+    auto it = std::find_if(nested.begin(),
+                           nested.end(),
+                           [](auto const& t)
+                           {
+                             auto t0 = std::get<0>(t);
+                             return std::get<0>(t0) == 75000;
+                           });
+    benchmark::DoNotOptimize(it);
+  }
+}
+
+static void BM_StdNestedZipFindIf(benchmark::State& s) { BM_NestedZipFindIf_impl<false>(s); }
+static void BM_GstNestedZipFindIf(benchmark::State& s) { BM_NestedZipFindIf_impl<true>(s); }
+
+BENCHMARK(BM_StdNestedZipFindIf);
+BENCHMARK(BM_GstNestedZipFindIf);
+
+template <bool UseGst>
+static void BM_NestedZipForEach_impl(benchmark::State& state)
+{
+  std::vector<int> v1(100000);
+  std::vector<int> v2(100000);
+  std::vector<int> v3(100000);
+  std::vector<int> v4(100000);
+
+  std::iota(v1.begin(), v1.end(), 0);
+  std::iota(v2.begin(), v2.end(), 100000);
+  std::iota(v3.begin(), v3.end(), 200000);
+  std::iota(v4.begin(), v4.end(), 300000);
+
+  auto make_zip = [](auto&&... args)
+  {
+    if constexpr (UseGst)
+      return gst_zip(std::forward<decltype(args)>(args)...);
+    else
+      return std_zip(std::forward<decltype(args)>(args)...);
+  };
+
+  auto zip1   = make_zip(v1, v2);
+  auto zip2   = make_zip(v3, v4);
+  auto nested = make_zip(zip1, zip2);
+
+  for (auto _ : state)
+  {
+    int sum = 0;
+    std::for_each(nested.begin(),
+                  nested.end(),
+                  [&sum](auto t)
+                  {
+                    auto t0 = std::get<0>(t);
+                    auto t1 = std::get<1>(t);
+                    sum += std::get<0>(t0) + std::get<1>(t0) + std::get<0>(t1) + std::get<1>(t1);
+                  });
+    benchmark::DoNotOptimize(sum);
+  }
+}
+
+static void BM_StdNestedZipForEach(benchmark::State& s) { BM_NestedZipForEach_impl<false>(s); }
+static void BM_GstNestedZipForEach(benchmark::State& s) { BM_NestedZipForEach_impl<true>(s); }
+
+BENCHMARK(BM_StdNestedZipForEach);
+BENCHMARK(BM_GstNestedZipForEach);
+
+template <bool UseGst>
+static void BM_NestedZipIterate2x2x2_impl(benchmark::State& state)
+{
+  std::vector<int> v1(50000);
+  std::vector<int> v2(50000);
+  std::vector<int> v3(50000);
+  std::vector<int> v4(50000);
+  std::vector<int> v5(50000);
+  std::vector<int> v6(50000);
+  std::vector<int> v7(50000);
+  std::vector<int> v8(50000);
+
+  std::iota(v1.begin(), v1.end(), 0);
+  std::iota(v2.begin(), v2.end(), 50000);
+  std::iota(v3.begin(), v3.end(), 100000);
+  std::iota(v4.begin(), v4.end(), 150000);
+  std::iota(v5.begin(), v5.end(), 200000);
+  std::iota(v6.begin(), v6.end(), 250000);
+  std::iota(v7.begin(), v7.end(), 300000);
+  std::iota(v8.begin(), v8.end(), 350000);
+
+  auto make_zip = [](auto&&... args)
+  {
+    if constexpr (UseGst)
+      return gst_zip(std::forward<decltype(args)>(args)...);
+    else
+      return std_zip(std::forward<decltype(args)>(args)...);
+  };
+
+  auto zip1_1 = make_zip(v1, v2);
+  auto zip1_2 = make_zip(v3, v4);
+  auto zip2_1 = make_zip(v5, v6);
+  auto zip2_2 = make_zip(v7, v8);
+  auto nested = make_zip(zip1_1, zip1_2, zip2_1, zip2_2);
+
+  for (auto _ : state)
+  {
+    int sum = 0;
+    for (auto t : nested)
+    {
+      auto t0  = std::get<0>(t);
+      auto t1  = std::get<1>(t);
+      auto t2  = std::get<2>(t);
+      auto t3  = std::get<3>(t);
+      sum     += std::get<0>(t0) + std::get<1>(t0) + std::get<0>(t1) + std::get<1>(t1) +
+             std::get<0>(t2) + std::get<1>(t2) + std::get<0>(t3) + std::get<1>(t3);
+    }
+    benchmark::DoNotOptimize(sum);
+  }
+}
+
+static void BM_StdNestedZipIterate2x2x2(benchmark::State& s)
+{
+  BM_NestedZipIterate2x2x2_impl<false>(s);
+}
+static void BM_GstNestedZipIterate2x2x2(benchmark::State& s)
+{
+  BM_NestedZipIterate2x2x2_impl<true>(s);
+}
+
+BENCHMARK(BM_StdNestedZipIterate2x2x2);
+BENCHMARK(BM_GstNestedZipIterate2x2x2);
+
+template <bool UseGst>
+static void BM_DeepNestedZipIterate_impl(benchmark::State& state)
+{
+  std::vector<int> v1(50000);
+  std::vector<int> v2(50000);
+  std::vector<int> v3(50000);
+  std::vector<int> v4(50000);
+  std::vector<int> v5(50000);
+  std::vector<int> v6(50000);
+  std::vector<int> v7(50000);
+  std::vector<int> v8(50000);
+
+  std::iota(v1.begin(), v1.end(), 0);
+  std::iota(v2.begin(), v2.end(), 50000);
+  std::iota(v3.begin(), v3.end(), 100000);
+  std::iota(v4.begin(), v4.end(), 150000);
+  std::iota(v5.begin(), v5.end(), 200000);
+  std::iota(v6.begin(), v6.end(), 250000);
+  std::iota(v7.begin(), v7.end(), 300000);
+  std::iota(v8.begin(), v8.end(), 350000);
+
+  auto make_zip = [](auto&&... args)
+  {
+    if constexpr (UseGst)
+      return gst_zip(std::forward<decltype(args)>(args)...);
+    else
+      return std_zip(std::forward<decltype(args)>(args)...);
+  };
+
+  auto zip1_1      = make_zip(v1, v2);
+  auto zip1_2      = make_zip(v3, v4);
+  auto zip2_1      = make_zip(v5, v6);
+  auto zip2_2      = make_zip(v7, v8);
+  auto nested_1    = make_zip(zip1_1, zip1_2);
+  auto nested_2    = make_zip(zip2_1, zip2_2);
+  auto deep_nested = make_zip(nested_1, nested_2);
+
+  for (auto _ : state)
+  {
+    int sum = 0;
+    for (auto t : deep_nested)
+    {
+      auto n0   = std::get<0>(t);
+      auto n1   = std::get<1>(t);
+      auto t00  = std::get<0>(n0);
+      auto t01  = std::get<1>(n0);
+      auto t10  = std::get<0>(n1);
+      auto t11  = std::get<1>(n1);
+      sum      += std::get<0>(t00) + std::get<1>(t00) + std::get<0>(t01) + std::get<1>(t01) +
+             std::get<0>(t10) + std::get<1>(t10) + std::get<0>(t11) + std::get<1>(t11);
+    }
+    benchmark::DoNotOptimize(sum);
+  }
+}
+
+static void BM_StdDeepNestedZipIterate(benchmark::State& s)
+{
+  BM_DeepNestedZipIterate_impl<false>(s);
+}
+static void BM_GstDeepNestedZipIterate(benchmark::State& s)
+{
+  BM_DeepNestedZipIterate_impl<true>(s);
+}
+
+BENCHMARK(BM_StdDeepNestedZipIterate);
+BENCHMARK(BM_GstDeepNestedZipIterate);
+
+template <bool UseGst>
+static void BM_NestedZipSubscriptAccess_impl(benchmark::State& state)
+{
+  std::vector<int> v1(100000);
+  std::vector<int> v2(100000);
+  std::vector<int> v3(100000);
+  std::vector<int> v4(100000);
+
+  std::iota(v1.begin(), v1.end(), 0);
+  std::iota(v2.begin(), v2.end(), 100000);
+  std::iota(v3.begin(), v3.end(), 200000);
+  std::iota(v4.begin(), v4.end(), 300000);
+
+  auto make_zip = [](auto&&... args)
+  {
+    if constexpr (UseGst)
+      return gst_zip(std::forward<decltype(args)>(args)...);
+    else
+      return std_zip(std::forward<decltype(args)>(args)...);
+  };
+
+  auto zip1   = make_zip(v1, v2);
+  auto zip2   = make_zip(v3, v4);
+  auto nested = make_zip(zip1, zip2);
+
+  for (auto _ : state)
+  {
+    int sum = 0;
+    for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(nested.size()); ++i)
+    {
+      auto t   = nested[i];
+      auto t0  = std::get<0>(t);
+      auto t1  = std::get<1>(t);
+      sum     += std::get<0>(t0) + std::get<1>(t0) + std::get<0>(t1) + std::get<1>(t1);
+    }
+    benchmark::DoNotOptimize(sum);
+  }
+}
+
+static void BM_StdNestedZipSubscriptAccess(benchmark::State& s)
+{
+  BM_NestedZipSubscriptAccess_impl<false>(s);
+}
+static void BM_GstNestedZipSubscriptAccess(benchmark::State& s)
+{
+  BM_NestedZipSubscriptAccess_impl<true>(s);
+}
+
+BENCHMARK(BM_StdNestedZipSubscriptAccess);
+BENCHMARK(BM_GstNestedZipSubscriptAccess);

--- a/include/zip_view.hpp
+++ b/include/zip_view.hpp
@@ -259,14 +259,14 @@ private:
   template <std::size_t... Is>
   auto subscripts(std::ptrdiff_t const index, detail::index_sequence<Is...>) -> references
   {
-    return std::tie(*std::next(std::get<Is>(views_).begin(), index)...);
+    return references(*std::next(std::get<Is>(views_).begin(), index)...);
   }
 
   template <std::size_t... Is>
   auto subscripts(std::ptrdiff_t const index,
                   detail::index_sequence<Is...>) const -> const_references
   {
-    return std::tie(*std::next(std::get<Is>(views_).begin(), index)...);
+    return const_references(*std::next(std::get<Is>(views_).begin(), index)...);
   }
 
 public:
@@ -320,13 +320,13 @@ public:
     template <std::size_t... Is>
     auto dereference(detail::index_sequence<Is...>) -> deref_tuple<Is...>
     {
-      return std::tie(*std::get<Is>(iters_)...);
+      return deref_tuple<Is...>(*std::get<Is>(iters_)...);
     }
 
     template <std::size_t... Is>
     auto dereference(detail::index_sequence<Is...>) const -> deref_tuple<Is...>
     {
-      return std::tie(*std::get<Is>(iters_)...);
+      return deref_tuple<Is...>(*std::get<Is>(iters_)...);
     }
 
   public:

--- a/include/zip_view.hpp
+++ b/include/zip_view.hpp
@@ -454,14 +454,12 @@ public:
       return !(*this < other);
     }
 
-    // Friend function for n + iterator
     template <bool B = is_random_access, typename std::enable_if<B, int>::type = 0>
     friend auto operator+(difference_type const n, basic_iterator const& it) -> basic_iterator
     {
       return it + n;
     }
 
-    // Custom iter_swap for proper swapping of zipped elements
     friend auto iter_swap(basic_iterator const& lhs, basic_iterator const& rhs) noexcept -> void
     {
       iter_swap_impl(lhs, rhs, INDICES);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ if(CODE_COVERAGE)
   find_program(GCOVR_EXE NAMES gcovr)
   if(GCOVR_EXE)
     # Common gcovr args
-    set(GCOVR_FILTER_ARGS --filter ${CMAKE_SOURCE_DIR}/include/ --exclude-throw-branches)
+    set(GCOVR_FILTER_ARGS --filter ${CMAKE_SOURCE_DIR}/include/ --exclude ${CMAKE_SOURCE_DIR}/tests/ --exclude-throw-branches)
     set(GCOVR_GCOV_OPTION "")
 
     # For Clang, prefer using llvm-cov as the gcov wrapper

--- a/tests/algo.cpp
+++ b/tests/algo.cpp
@@ -1345,3 +1345,404 @@ SCENARIO("std::unique works on sorted zip_view", "[algorithms][unique]")
     }
   }
 }
+
+SCENARIO("Using std::for_each on nested zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {1, 2, 3};
+  std::vector<int> v2 = {4, 5, 6};
+  std::vector<int> v3 = {7, 8, 9};
+  std::vector<int> v4 = {10, 11, 12};
+
+  auto zip1   = gst::ranges::views::zip(v1, v2);
+  auto zip2   = gst::ranges::views::zip(v3, v4);
+  auto nested = gst::ranges::views::zip(zip1, zip2);
+
+  THEN("std::for_each can iterate and access nested elements")
+  {
+    int  sum         = 0;
+    auto collect_sum = [&sum](auto elem)
+    {
+      auto t0  = std::get<0>(elem);
+      sum     += std::get<0>(t0) + std::get<1>(t0);
+    };
+    auto [zip_end, _] = std::ranges::for_each(nested, collect_sum);
+    REQUIRE(zip_end == nested.end());
+    REQUIRE(sum == 21);
+  }
+
+  THEN("std::for_each can modify elements through nested zip_view")
+  {
+    auto multiply_first_by_10 = [](auto&& elem)
+    {
+      auto t0          = std::get<0>(elem);
+      std::get<0>(t0) *= 10;
+    };
+    auto [zip_end2, _2] = std::ranges::for_each(nested, multiply_first_by_10);
+    REQUIRE(zip_end2 == nested.end());
+    REQUIRE(v1 == std::vector<int>{10, 20, 30});
+  }
+}
+
+SCENARIO("Using std::count_if on nested zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {1, 2, 3, 4, 5};
+  std::vector<int> v2 = {2, 4, 6, 8, 10};
+  std::vector<int> v3 = {1, 3, 5, 7, 9};
+
+  auto nested = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+
+  THEN("std::count_if works on nested zip_views")
+  {
+    auto v1_greater_than_2 = [](auto elem)
+    {
+      auto t0 = std::get<0>(elem);
+      return std::get<0>(t0) > 2;
+    };
+    auto count = std::ranges::count_if(nested, v1_greater_than_2);
+    REQUIRE(count == 3);
+  }
+
+  THEN("std::count_if with complex predicate on nested elements")
+  {
+    auto complex_pred = [](auto elem)
+    {
+      auto t0      = std::get<0>(elem);
+      auto regular = std::get<1>(elem);
+      return std::get<1>(t0) % 4 == 0 && regular % 2 == 1;
+    };
+    auto count = std::ranges::count_if(nested, complex_pred);
+    REQUIRE(count == 2);
+  }
+}
+
+SCENARIO("Using std::transform on nested zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {1, 2, 3};
+  std::vector<int> v2 = {10, 20, 30};
+  std::vector<int> v3 = {100, 200, 300};
+
+  auto zip1   = gst::ranges::views::zip(v1, v2);
+  auto zip2   = gst::ranges::views::zip(v2, v3);
+  auto nested = gst::ranges::views::zip(zip1, zip2);
+
+  std::vector<int> results;
+
+  THEN("std::transform can extract and combine nested elements")
+  {
+    auto extract_and_add = [](auto elem)
+    {
+      auto t0 = std::get<0>(elem);
+      auto t1 = std::get<1>(elem);
+      return std::get<0>(t0) + std::get<1>(t1);
+    };
+    std::ranges::transform(nested, std::back_inserter(results), extract_and_add);
+    REQUIRE(results == std::vector<int>{101, 202, 303});
+  }
+}
+
+SCENARIO("Using std::any_of and std::all_of on nested zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {2, 4, 6};
+  std::vector<int> v2 = {1, 3, 5};
+  std::vector<int> v3 = {10, 20, 30};
+
+  auto nested = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+
+  THEN("std::any_of works on nested zip_views")
+  {
+    auto has_even_pred = [](auto elem)
+    {
+      auto t0 = std::get<0>(elem);
+      return std::get<0>(t0) % 2 == 0;
+    };
+    bool has_even_in_first = std::ranges::any_of(nested, has_even_pred);
+    REQUIRE(has_even_in_first);
+  }
+
+  THEN("std::all_of works on nested zip_views")
+  {
+    bool all_positive =
+      std::all_of(nested.begin(),
+                  nested.end(),
+                  [](auto elem) { return std::get<0>(elem) > std::make_tuple(0, 0); });
+    REQUIRE(all_positive);
+  }
+}
+
+SCENARIO("Using std::find_if on nested zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {1, 2, 3, 4, 5};
+  std::vector<int> v2 = {10, 20, 30, 40, 50};
+  std::vector<int> v3 = {5, 4, 3, 2, 1};
+
+  auto zip1   = gst::ranges::views::zip(v1, v2);
+  auto zip2   = gst::ranges::views::zip(v2, v3);
+  auto nested = gst::ranges::views::zip(zip1, zip2);
+
+  THEN("std::find_if can locate specific nested elements")
+  {
+    auto find_v1_eq_3 = [](auto elem)
+    {
+      auto t0 = std::get<0>(elem);
+      return std::get<0>(t0) == 3;
+    };
+    auto it = std::ranges::find_if(nested, find_v1_eq_3);
+
+    REQUIRE(it != nested.end());
+    auto found = *it;
+    auto t0    = std::get<0>(found);
+    REQUIRE(std::get<1>(t0) == 30);
+  }
+}
+
+SCENARIO("Using std::fold_left on nested zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {1, 2, 3};
+  std::vector<int> v2 = {4, 5, 6};
+  std::vector<int> v3 = {7, 8, 9};
+
+  auto nested = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+
+  THEN("std::fold_left can sum nested elements")
+  {
+    auto fold_sum = [](int acc, auto elem)
+    {
+      auto t0 = std::get<0>(elem);
+      return acc + std::get<0>(t0) + std::get<1>(elem);
+    };
+    int sum = std::ranges::fold_left(nested, 0, fold_sum);
+    REQUIRE(sum == 30);
+  }
+}
+
+SCENARIO("Using std::copy_if with nested zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {1, 2, 3, 4, 5};
+  std::vector<int> v2 = {10, 20, 30, 40, 50};
+  std::vector<int> v3 = {2, 4, 6, 8, 10};
+
+  auto             nested = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+  std::vector<int> selected;
+
+  THEN("std::copy_if can filter and extract from nested zip_views")
+  {
+    auto select_and_append = [&selected](auto elem)
+    {
+      auto t0 = std::get<0>(elem);
+      if (std::get<0>(t0) > 2) selected.push_back(std::get<0>(t0));
+    };
+    std::ranges::for_each(nested, select_and_append);
+    REQUIRE(selected == std::vector<int>{3, 4, 5});
+  }
+}
+
+SCENARIO("For-each on inline temporary nested zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {1, 2, 3, 4};
+  std::vector<int> v2 = {10, 20, 30, 40};
+  std::vector<int> v3 = {100, 200, 300, 400};
+  std::vector<int> v4 = {5, 6, 7, 8};
+
+  THEN("Can apply std::for_each directly to temporary nested zip_view")
+  {
+    int  sum            = 0;
+    auto tmp_accumulate = [&sum](auto elem)
+    {
+      auto t0  = std::get<0>(elem);
+      auto t1  = std::get<1>(elem);
+      sum     += std::get<0>(t0) + std::get<0>(t1);
+    };
+    auto [tmp_it, _tmp] = std::ranges::for_each(
+      gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), gst::ranges::views::zip(v3, v4)),
+      tmp_accumulate);
+    (void)tmp_it;
+    REQUIRE(sum == 1010);
+  }
+
+  THEN("Can modify through std::for_each on temporary nested zip_view")
+  {
+    auto tmp_double_second = [](auto&& elem)
+    {
+      auto t0          = std::get<0>(elem);
+      std::get<1>(t0) *= 2;
+    };
+    std::ranges::for_each(gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v4),
+                          tmp_double_second);
+    REQUIRE(v2 == std::vector<int>{20, 40, 60, 80});
+  }
+}
+
+SCENARIO("Count_if on inline temporary nested zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {1, 2, 3, 4, 5};
+  std::vector<int> v2 = {2, 4, 6, 8, 10};
+  std::vector<int> v3 = {10, 20, 30, 40, 50};
+
+  THEN("std::count_if works directly on temporary nested zip_view")
+  {
+    auto tmp_count_pred = [](auto elem)
+    {
+      auto t0 = std::get<0>(elem);
+      return std::get<0>(t0) > 2 && std::get<1>(t0) % 4 == 0;
+    };
+    auto count = std::ranges::count_if(gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3),
+                                       tmp_count_pred);
+    REQUIRE(count == 1);
+  }
+}
+
+SCENARIO("Any_of on inline temporary nested zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {1, 3, 5, 7};
+  std::vector<int> v2 = {2, 4, 6, 8};
+  std::vector<int> v3 = {10, 20, 30, 40};
+
+  THEN("std::any_of works on temporary nested zip_view")
+  {
+    auto tmp_any_pred = [](auto elem)
+    {
+      auto t0 = std::get<0>(elem);
+      return std::get<0>(t0) + std::get<1>(t0) + std::get<1>(elem) > 50;
+    };
+    bool has_sum_greater_than_50 = std::ranges::any_of(
+      gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3), tmp_any_pred);
+    REQUIRE(has_sum_greater_than_50);
+  }
+}
+
+SCENARIO("Transform on inline temporary nested zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {1, 2, 3};
+  std::vector<int> v2 = {4, 5, 6};
+  std::vector<int> v3 = {7, 8, 9};
+  std::vector<int> v4 = {10, 11, 12};
+  std::vector<int> results;
+
+  THEN("std::transform works on temporary nested zip_view")
+  {
+    auto tmp_transform = [](auto elem)
+    {
+      auto t0 = std::get<0>(elem);
+      auto t1 = std::get<1>(elem);
+      return std::get<0>(t0) + std::get<1>(t0) + std::get<0>(t1) + std::get<1>(t1);
+    };
+    std::ranges::transform(
+      gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), gst::ranges::views::zip(v3, v4)),
+      std::back_inserter(results),
+      tmp_transform);
+    REQUIRE(results == std::vector<int>{22, 26, 30});
+  }
+}
+
+SCENARIO("Find_if on inline temporary nested zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {10, 20, 30, 40, 50};
+  std::vector<int> v2 = {1, 2, 3, 4, 5};
+  std::vector<int> v3 = {5, 4, 3, 2, 1};
+
+  THEN("std::find_if locates element in temporary nested zip_view")
+  {
+    auto temp_zip = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+    auto tmp_find = [](auto elem)
+    {
+      auto t0 = std::get<0>(elem);
+      return std::get<0>(t0) == 30;
+    };
+    auto it = std::ranges::find_if(temp_zip, tmp_find);
+
+    REQUIRE(it != temp_zip.end());
+    auto found = *it;
+    auto t0    = std::get<0>(found);
+    REQUIRE(std::get<1>(t0) == 3);
+    REQUIRE(std::get<1>(found) == 3);
+  }
+}
+
+SCENARIO("Accumulate on inline temporary nested zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {1, 2, 3};
+  std::vector<int> v2 = {10, 20, 30};
+  std::vector<int> v3 = {100, 200, 300};
+
+  THEN("std::fold_left works on temporary nested zip_view")
+  {
+    auto temp     = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+    auto tmp_fold = [](int acc, auto elem)
+    {
+      auto t0 = std::get<0>(elem);
+      return acc * std::get<0>(t0);
+    };
+    int product = std::ranges::fold_left(temp, 1, tmp_fold);
+    REQUIRE(product == 6);
+  }
+}
+
+SCENARIO("All_of on deeply nested temporary zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {1, 2, 3};
+  std::vector<int> v2 = {4, 5, 6};
+  std::vector<int> v3 = {7, 8, 9};
+  std::vector<int> v4 = {10, 11, 12};
+  std::vector<int> v5 = {2, 2, 2};
+
+  THEN("std::all_of works on deeply nested temporary zip_view")
+  {
+    auto tmp_all_pred = [](auto elem) { return std::get<1>(elem) > 0; };
+    bool all_positive = std::ranges::all_of(
+      gst::ranges::views::zip(
+        gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), gst::ranges::views::zip(v3, v4)),
+        v5),
+      tmp_all_pred);
+    REQUIRE(all_positive);
+  }
+}
+
+SCENARIO("Chaining algorithms on inline temporary nested zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {1, 2, 3, 4, 5};
+  std::vector<int> v2 = {10, 20, 30, 40, 50};
+  std::vector<int> v3 = {5, 4, 3, 2, 1};
+
+  THEN("Can chain multiple algorithm operations on temporary nested zip_view")
+  {
+    auto temp = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+
+    auto count_pred = [](auto elem)
+    {
+      auto t0 = std::get<0>(elem);
+      return std::get<0>(t0) > 2;
+    };
+    auto count = std::ranges::count_if(temp, count_pred);
+    REQUIRE(count == 3);
+
+    auto find_pred = [](auto elem) { return std::get<1>(elem) < 3; };
+    auto it        = std::ranges::find_if(temp, find_pred);
+    REQUIRE(it != temp.end());
+
+    auto sum_proj = [](int acc, auto elem)
+    {
+      auto t0 = std::get<0>(elem);
+      return acc + std::get<1>(t0);
+    };
+    int sum = std::ranges::fold_left(temp, 0, sum_proj);
+    REQUIRE(sum == 150);
+  }
+}
+
+SCENARIO("Range-based for on inline temporary nested zip_views", "[zip_view][nested][algo]")
+{
+  std::vector<int> v1 = {1, 2, 3};
+  std::vector<int> v2 = {4, 5, 6};
+  std::vector<int> v3 = {7, 8, 9};
+
+  THEN("Can use range-based for on temporary created inline")
+  {
+    int sum = 0;
+    for (auto elem : gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3))
+    {
+      auto t0  = std::get<0>(elem);
+      sum     += std::get<0>(t0) + std::get<1>(elem);
+    }
+    REQUIRE(sum == 30);
+  }
+}

--- a/tests/base.cpp
+++ b/tests/base.cpp
@@ -474,3 +474,474 @@ SCENARIO("Testing assignment operators", "[zip_view]")
     }
   }
 }
+
+SCENARIO("Testing nested zip_views (zip of zip_views)", "[zip_view][nested]")
+{
+  {
+    GIVEN("Empty zip_views")
+    {
+      std::vector<int>  v1 = {};
+      std::vector<int>  v2 = {};
+      std::vector<char> v3 = {};
+      std::vector<char> v4 = {};
+
+      auto zip1 = gst::ranges::views::zip(v1, v2);
+      auto zip2 = gst::ranges::views::zip(v3, v4);
+
+      WHEN("Zipping two empty zip_views")
+      {
+        auto nested = gst::ranges::views::zip(zip1, zip2);
+
+        THEN("The nested zip_view is empty")
+        {
+          REQUIRE(nested.empty());
+          REQUIRE(nested.size() == 0);
+          REQUIRE(nested.begin() == nested.end());
+        }
+      }
+    }
+
+    GIVEN("A single zip_view with other containers")
+    {
+      std::vector<int>   v1 = {1, 2, 3};
+      std::vector<int>   v2 = {4, 5, 6};
+      std::vector<float> v3 = {1.1F, 2.2F, 3.3F};
+
+      auto zip1 = gst::ranges::views::zip(v1, v2);
+
+      WHEN("Zipping one zip_view with a regular container")
+      {
+        auto nested = gst::ranges::views::zip(zip1, v3);
+
+        THEN("The nested zip_view has correct size") { REQUIRE(nested.size() == 3); }
+
+        THEN("Can iterate through nested zip_view")
+        {
+          int count = 0;
+          for (auto it = nested.begin(); it != nested.end(); ++it) { ++count; }
+          REQUIRE(count == 3);
+        }
+
+        THEN("Can access and verify size")
+        {
+          REQUIRE(zip1.size() == 3);
+          REQUIRE(nested.size() == 3);
+          REQUIRE_FALSE(nested.empty());
+        }
+
+        THEN("Can access elements correctly using iterators")
+        {
+          auto it     = nested.begin();
+          auto elem0  = *it;
+          auto tuple0 = std::get<0>(elem0);
+          REQUIRE(std::get<0>(tuple0) == 1);
+          REQUIRE(std::get<1>(tuple0) == 4);
+          REQUIRE(std::get<1>(elem0) > 1.0F);
+          REQUIRE(std::get<1>(elem0) < 1.2F);
+
+          ++it;
+          auto elem1  = *it;
+          auto tuple1 = std::get<0>(elem1);
+          REQUIRE(std::get<0>(tuple1) == 2);
+          REQUIRE(std::get<1>(tuple1) == 5);
+          REQUIRE(std::get<1>(elem1) > 2.1F);
+          REQUIRE(std::get<1>(elem1) < 2.3F);
+        }
+
+        THEN("Can modify regular container elements through nested zip_view")
+        {
+          auto it          = nested.begin();
+          std::get<1>(*it) = 9.9F;
+          REQUIRE(v3[0] > 9.8F);
+          REQUIRE(v3[0] < 10.0F);
+        }
+      }
+    }
+
+    GIVEN("Multiple zip_views of the same length")
+    {
+      std::vector<int>  v1 = {1, 2, 3, 4};
+      std::vector<int>  v2 = {5, 6, 7, 8};
+      std::vector<char> v3 = {'a', 'b', 'c', 'd'};
+      std::vector<char> v4 = {'w', 'x', 'y', 'z'};
+      std::list<float>  v5 = {1.1F, 2.2F, 3.3F, 4.4F};
+      std::list<float>  v6 = {5.5F, 6.6F, 7.7F, 8.8F};
+
+      auto zip1 = gst::ranges::views::zip(v1, v2);
+      auto zip2 = gst::ranges::views::zip(v3, v4);
+      auto zip3 = gst::ranges::views::zip(v5, v6);
+
+      WHEN("Zipping three zip_views together")
+      {
+        auto nested = gst::ranges::views::zip(zip1, zip2, zip3);
+
+        THEN("The nested zip_view has correct size") { REQUIRE(nested.size() == 4); }
+
+        THEN("Can iterate and access all elements")
+        {
+          auto it    = nested.begin();
+          auto elem0 = *it;
+          REQUIRE((std::get<0>(elem0) == std::make_tuple(1, 5)));
+          REQUIRE((std::get<1>(elem0) == std::make_tuple('a', 'w')));
+          REQUIRE((std::get<2>(elem0) == std::make_tuple(1.1F, 5.5F)));
+
+          std::advance(it, 2);
+          auto elem2 = *it;
+          REQUIRE((std::get<0>(elem2) == std::make_tuple(3, 7)));
+          REQUIRE((std::get<1>(elem2) == std::make_tuple('c', 'y')));
+          REQUIRE((std::get<2>(elem2) == std::make_tuple(3.3F, 7.7F)));
+        }
+
+        THEN("Can modify all underlying containers through nested zip_view")
+        {
+          for (auto&& elem : nested)
+          {
+            std::get<0>(std::get<0>(elem)) += 100;
+            std::get<1>(std::get<1>(elem))  = 'Z';
+            std::get<0>(std::get<2>(elem)) += 10.0F;
+          }
+
+          REQUIRE(v1[0] == 101);
+          REQUIRE(v1[3] == 104);
+          REQUIRE(v4[0] == 'Z');
+          REQUIRE(v4[3] == 'Z');
+          REQUIRE(v5.front() > 11.0F);
+          REQUIRE(v5.front() < 11.2F);
+          REQUIRE(v5.back() > 14.3F);
+          REQUIRE(v5.back() < 14.5F);
+        }
+      }
+    }
+
+    GIVEN("Multiple zip_views of different lengths")
+    {
+      std::vector<int>  v1 = {1, 2, 3, 4, 5};
+      std::vector<int>  v2 = {10, 20, 30, 40, 50};
+      std::vector<char> v3 = {'a', 'b', 'c'};
+      std::vector<char> v4 = {'x', 'y', 'z'};
+      std::deque<float> v5 = {1.1F, 2.2F};
+      std::deque<float> v6 = {9.9F, 8.8F};
+
+      auto zip1 = gst::ranges::views::zip(v1, v2);
+      auto zip2 = gst::ranges::views::zip(v3, v4);
+      auto zip3 = gst::ranges::views::zip(v5, v6);
+
+      WHEN("Zipping zip_views of different lengths")
+      {
+        auto nested = gst::ranges::views::zip(zip1, zip2, zip3);
+
+        THEN("Size is limited by shortest zip_view") { REQUIRE(nested.size() == 2); }
+
+        THEN("Can access elements up to shortest length")
+        {
+          auto it    = nested.begin();
+          auto elem0 = *it;
+          REQUIRE((std::get<0>(elem0) == std::make_tuple(1, 10)));
+          REQUIRE((std::get<1>(elem0) == std::make_tuple('a', 'x')));
+          REQUIRE((std::get<2>(elem0) == std::make_tuple(1.1F, 9.9F)));
+
+          ++it;
+          auto elem1 = *it;
+          REQUIRE((std::get<0>(elem1) == std::make_tuple(2, 20)));
+          REQUIRE((std::get<1>(elem1) == std::make_tuple('b', 'y')));
+          REQUIRE((std::get<2>(elem1) == std::make_tuple(2.2F, 8.8F)));
+        }
+
+        THEN("front() and back() work correctly")
+        {
+          auto front = nested.front();
+          REQUIRE((std::get<0>(front) == std::make_tuple(1, 10)));
+
+          auto back = nested.back();
+          REQUIRE((std::get<0>(back) == std::make_tuple(2, 20)));
+        }
+      }
+    }
+
+    GIVEN("Mixed: zip_views and regular containers")
+    {
+      std::vector<int>   v1 = {1, 2, 3};
+      std::vector<int>   v2 = {10, 20, 30};
+      std::vector<char>  v3 = {'a', 'b', 'c'};
+      std::vector<char>  v4 = {'x', 'y', 'z'};
+      std::vector<float> v5 = {1.1F, 2.2F, 3.3F};
+      std::list<double>  v6 = {100.0, 200.0, 300.0};
+
+      auto zip1 = gst::ranges::views::zip(v1, v2);
+      auto zip2 = gst::ranges::views::zip(v3, v4);
+
+      WHEN("Zipping mix of zip_views and regular containers")
+      {
+        auto mixed = gst::ranges::views::zip(zip1, v5, zip2, v6);
+
+        THEN("The mixed zip_view has correct size") { REQUIRE(mixed.size() == 3); }
+
+        THEN("Can iterate through mixed structure")
+        {
+          int count = 0;
+          for (auto it = mixed.begin(); it != mixed.end(); ++it) { ++count; }
+          REQUIRE(count == 3);
+        }
+
+        THEN("Can access regular container elements")
+        {
+          auto it = mixed.begin();
+          ++it;
+          auto elem1 = *it;
+          REQUIRE((std::get<0>(elem1) == std::make_tuple(2, 20)));
+          REQUIRE(std::get<1>(elem1) > 2.1F);
+          REQUIRE(std::get<1>(elem1) < 2.3F);
+          REQUIRE((std::get<2>(elem1) == std::make_tuple('b', 'y')));
+          REQUIRE(std::get<3>(elem1) > 199.0);
+          REQUIRE(std::get<3>(elem1) < 201.0);
+        }
+
+        THEN("Can modify regular container elements through mixed structure")
+        {
+          for (auto&& elem : mixed)
+          {
+            std::get<1>(std::get<0>(elem)) *= 10;
+            std::get<1>(elem)              += 100.0F;
+          }
+
+          REQUIRE(v2 == std::vector<int>{100, 200, 300});
+          REQUIRE(v5 == std::vector<float>{101.1F, 102.2F, 103.3F});
+        }
+      }
+    }
+
+    GIVEN("Nested zip_views with different container types")
+    {
+      std::array<int, 3> arr1 = {1, 2, 3};
+      std::list<int>     lst1 = {4, 5, 6};
+      std::deque<char>   deq1 = {'a', 'b', 'c'};
+      std::vector<char>  vec1 = {'x', 'y', 'z'};
+
+      auto zip1 = gst::ranges::views::zip(arr1, lst1);
+      auto zip2 = gst::ranges::views::zip(deq1, vec1);
+
+      WHEN("Zipping zip_views with different underlying container types")
+      {
+        auto nested = gst::ranges::views::zip(zip1, zip2);
+
+        THEN("Size matches shortest container") { REQUIRE(nested.size() == 3); }
+
+        THEN("front() returns first elements")
+        {
+          auto front = nested.front();
+          REQUIRE((std::get<0>(front) == std::make_tuple(1, 4)));
+          REQUIRE((std::get<1>(front) == std::make_tuple('a', 'x')));
+        }
+
+        THEN("back() returns last elements")
+        {
+          auto back = nested.back();
+          REQUIRE((std::get<0>(back) == std::make_tuple(3, 6)));
+          REQUIRE((std::get<1>(back) == std::make_tuple('c', 'z')));
+        }
+
+        THEN("Can iterate with range-based for loop")
+        {
+          int count = 0;
+          for (auto elem : nested)
+          {
+            (void)elem;
+            ++count;
+          }
+          REQUIRE(count == 3);
+        }
+      }
+    }
+
+    GIVEN("Deeply nested zip_views")
+    {
+      std::vector<int> v1 = {1, 2};
+      std::vector<int> v2 = {3, 4};
+      std::vector<int> v3 = {5, 6};
+      std::vector<int> v4 = {7, 8};
+
+      auto zip1 = gst::ranges::views::zip(v1, v2);
+      auto zip2 = gst::ranges::views::zip(v3, v4);
+      auto zip3 = gst::ranges::views::zip(zip1, zip2);
+
+      WHEN("Creating another zip from nested zip_views")
+      {
+        std::vector<int> v5   = {9, 10};
+        auto             zip4 = gst::ranges::views::zip(zip3, v5);
+
+        THEN("Deeply nested structure has correct size") { REQUIRE(zip4.size() == 2); }
+
+        THEN("Can access deeply nested elements")
+        {
+          auto it    = zip4.begin();
+          auto elem0 = *it;
+          REQUIRE(std::get<1>(elem0) == 9);
+
+          auto nested_tuple = std::get<0>(elem0);
+          REQUIRE((std::get<0>(nested_tuple) == std::make_tuple(1, 3)));
+          REQUIRE((std::get<1>(nested_tuple) == std::make_tuple(5, 7)));
+        }
+
+        THEN("Can modify through deep nesting")
+        {
+          auto it          = zip4.begin();
+          std::get<1>(*it) = 99;
+          REQUIRE(v5[0] == 99);
+        }
+
+        THEN("All nested structures have correct sizes")
+        {
+          REQUIRE(zip1.size() == 2);
+          REQUIRE(zip2.size() == 2);
+          REQUIRE(zip3.size() == 2);
+          REQUIRE(zip4.size() == 2);
+        }
+      }
+    }
+
+    GIVEN("Zip_views with one element each")
+    {
+      std::vector<int>  v1 = {42};
+      std::vector<int>  v2 = {84};
+      std::vector<char> v3 = {'X'};
+
+      auto zip1 = gst::ranges::views::zip(v1);
+      auto zip2 = gst::ranges::views::zip(v2, v3);
+
+      WHEN("Zipping single-element zip_views")
+      {
+        auto nested = gst::ranges::views::zip(zip1, zip2);
+
+        THEN("Size is 1") { REQUIRE(nested.size() == 1); }
+
+        THEN("Element is accessible")
+        {
+          auto it   = nested.begin();
+          auto elem = *it;
+          REQUIRE((std::get<0>(elem) == std::make_tuple(42)));
+          REQUIRE((std::get<1>(elem) == std::make_tuple(84, 'X')));
+        }
+
+        THEN("Can iterate once")
+        {
+          int count = 0;
+          for (auto it = nested.begin(); it != nested.end(); ++it) { ++count; }
+          REQUIRE(count == 1);
+        }
+      }
+    }
+
+    GIVEN("Comparison with std::ranges::zip_view")
+    {
+      std::vector<int> v1 = {1, 2, 3};
+      std::vector<int> v2 = {4, 5, 6};
+      std::vector<int> v3 = {7, 8, 9};
+      std::vector<int> v4 = {10, 11, 12};
+
+      auto gst_zip1 = gst::ranges::views::zip(v1, v2, v3);
+      auto gst_zip2 = gst::ranges::views::zip(v2, v3, v4);
+      auto gst_zip3 = gst::ranges::views::zip(v4, v1, v2);
+      auto std_zip1 = std::ranges::views::zip(v1, v2, v3);
+      auto std_zip2 = std::ranges::views::zip(v2, v3, v4);
+      auto std_zip3 = std::ranges::views::zip(v4, v1, v2);
+
+      WHEN("Comparing nested gst::zip_view with std::ranges::zip_view")
+      {
+        auto gst_nested = gst::ranges::views::zip(gst_zip1, gst_zip2, gst_zip3);
+        auto std_nested = std::ranges::views::zip(std_zip1, std_zip2, std_zip3);
+
+        THEN("Sizes match") { REQUIRE(gst_nested.size() == std_nested.size()); }
+
+        THEN("Elements match")
+        {
+          auto gst_it = gst_nested.begin();
+          auto std_it = std_nested.begin();
+
+          while (gst_it != gst_nested.end() && std_it != std_nested.end())
+          {
+            REQUIRE((*gst_it == *std_it));
+            ++gst_it;
+            ++std_it;
+          }
+          REQUIRE(gst_it == gst_nested.end());
+          REQUIRE(std_it == std_nested.end());
+        }
+      }
+    }
+
+    GIVEN("Very large nested zip_views")
+    {
+      std::vector<int> v1(10'000, 1);
+      std::vector<int> v2(10'000, 2);
+      std::vector<int> v3(10'000, 3);
+      std::vector<int> v4(10'000, 4);
+
+      auto zip1 = gst::ranges::views::zip(v1, v2);
+      auto zip2 = gst::ranges::views::zip(v3, v4);
+
+      WHEN("Creating large nested zip_views")
+      {
+        auto nested = gst::ranges::views::zip(zip1, zip2);
+
+        THEN("Size is correct") { REQUIRE(nested.size() == 10'000); }
+
+        THEN("Can iterate through all elements")
+        {
+          int count = 0;
+          for (auto it = nested.begin(); it != nested.end(); ++it)
+          {
+            ++count;
+            if (count >= 100) break;
+          }
+          REQUIRE(count == 100);
+        }
+
+        THEN("Can access and modify elements")
+        {
+          auto elem = nested[5000];
+          REQUIRE((std::get<0>(elem) == std::make_tuple(1, 2)));
+          REQUIRE((std::get<1>(elem) == std::make_tuple(3, 4)));
+
+          std::get<0>(std::get<0>(elem)) = 999;
+          REQUIRE(v1[5000] == 999);
+        }
+      }
+    }
+
+    GIVEN("Multiple levels of nesting")
+    {
+      std::vector<int> v1 = {1, 2, 3};
+      std::vector<int> v2 = {4, 5, 6};
+      std::vector<int> v3 = {7, 8, 9};
+      std::vector<int> v4 = {10, 11, 12};
+      std::vector<int> v5 = {13, 14, 15};
+      std::vector<int> v6 = {16, 17, 18};
+
+      WHEN("Creating multiple levels of nested zip_views")
+      {
+        auto zip1 = gst::ranges::views::zip(v1, v2);
+        auto zip2 = gst::ranges::views::zip(v3, v4);
+        auto zip3 = gst::ranges::views::zip(v5, v6);
+
+        auto level1 = gst::ranges::views::zip(zip1, zip2);
+        auto level2 = gst::ranges::views::zip(level1, zip3);
+
+        THEN("All levels have correct sizes")
+        {
+          REQUIRE(zip1.size() == 3);
+          REQUIRE(zip2.size() == 3);
+          REQUIRE(zip3.size() == 3);
+          REQUIRE(level1.size() == 3);
+          REQUIRE(level2.size() == 3);
+        }
+
+        THEN("Can iterate through multiple levels")
+        {
+          int count = 0;
+          for (auto it = level2.begin(); it != level2.end(); ++it) { ++count; }
+          REQUIRE(count == 3);
+        }
+      }
+    }
+  }
+}

--- a/tests/base.cpp
+++ b/tests/base.cpp
@@ -9,7 +9,8 @@
 #include <catch2/catch_test_macros.hpp>
 #endif
 
-#include <algorithm>
+#include <catch2/catch_approx.hpp>
+
 #include <array>
 #include <deque>
 #include <forward_list>
@@ -20,6 +21,33 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+SCENARIO("zip_view with various container combinations", "[zip_view]")
+{
+  GIVEN("Two vectors of int and char")
+  {
+    std::vector<int>  vec1 = {1, 2, 3};
+    std::vector<char> vec2 = {'a', 'b', 'c'};
+
+    auto gst_zipped = gst::ranges::views::zip(vec1, vec2);
+    auto std_zipped = std::ranges::views::zip(vec1, vec2);
+
+    THEN("The sizes match") { REQUIRE(gst_zipped.size() == std_zipped.size()); }
+    THEN("The view is not empty") { REQUIRE_FALSE(gst_zipped.empty()); }
+  }
+
+  GIVEN("Two vectors of same type")
+  {
+    std::vector<int> vec1 = {1, 2, 3};
+    std::vector<int> vec2 = {4, 5, 6};
+
+    auto gst_zipped = gst::ranges::views::zip(vec1, vec2);
+    auto std_zipped = std::ranges::views::zip(vec1, vec2);
+
+    THEN("The sizes match") { REQUIRE(gst_zipped.size() == std_zipped.size()); }
+    THEN("The view is not empty") { REQUIRE_FALSE(gst_zipped.empty()); }
+  }
+}
 
 SCENARIO("Comparing zip_view with std::ranges::zip_view using different containers and lengths",
          "[zip_view]")
@@ -536,24 +564,21 @@ SCENARIO("Testing nested zip_views (zip of zip_views)", "[zip_view][nested]")
           auto tuple0 = std::get<0>(elem0);
           REQUIRE(std::get<0>(tuple0) == 1);
           REQUIRE(std::get<1>(tuple0) == 4);
-          REQUIRE(std::get<1>(elem0) > 1.0F);
-          REQUIRE(std::get<1>(elem0) < 1.2F);
+          REQUIRE(std::get<1>(elem0) == Catch::Approx(1.1F));
 
           ++it;
           auto elem1  = *it;
           auto tuple1 = std::get<0>(elem1);
           REQUIRE(std::get<0>(tuple1) == 2);
           REQUIRE(std::get<1>(tuple1) == 5);
-          REQUIRE(std::get<1>(elem1) > 2.1F);
-          REQUIRE(std::get<1>(elem1) < 2.3F);
+          REQUIRE(std::get<1>(elem1) == Catch::Approx(2.2F));
         }
 
         THEN("Can modify regular container elements through nested zip_view")
         {
           auto it          = nested.begin();
           std::get<1>(*it) = 9.9F;
-          REQUIRE(v3[0] > 9.8F);
-          REQUIRE(v3[0] < 10.0F);
+          REQUIRE(v3[0] == Catch::Approx(9.9F));
         }
       }
     }
@@ -605,10 +630,8 @@ SCENARIO("Testing nested zip_views (zip of zip_views)", "[zip_view][nested]")
           REQUIRE(v1[3] == 104);
           REQUIRE(v4[0] == 'Z');
           REQUIRE(v4[3] == 'Z');
-          REQUIRE(v5.front() > 11.0F);
-          REQUIRE(v5.front() < 11.2F);
-          REQUIRE(v5.back() > 14.3F);
-          REQUIRE(v5.back() < 14.5F);
+          REQUIRE(v5.front() == Catch::Approx(11.1F));
+          REQUIRE(v5.back() == Catch::Approx(14.4F));
         }
       }
     }
@@ -689,11 +712,9 @@ SCENARIO("Testing nested zip_views (zip of zip_views)", "[zip_view][nested]")
           ++it;
           auto elem1 = *it;
           REQUIRE((std::get<0>(elem1) == std::make_tuple(2, 20)));
-          REQUIRE(std::get<1>(elem1) > 2.1F);
-          REQUIRE(std::get<1>(elem1) < 2.3F);
+          REQUIRE(std::get<1>(elem1) == Catch::Approx(2.2F));
           REQUIRE((std::get<2>(elem1) == std::make_tuple('b', 'y')));
-          REQUIRE(std::get<3>(elem1) > 199.0);
-          REQUIRE(std::get<3>(elem1) < 201.0);
+          REQUIRE(std::get<3>(elem1) == Catch::Approx(200.0));
         }
 
         THEN("Can modify regular container elements through mixed structure")

--- a/tests/edge.cpp
+++ b/tests/edge.cpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <deque>
 #include <list>
+#include <numeric>
 #include <ranges>
 #include <string>
 #include <tuple>

--- a/tests/edge.cpp
+++ b/tests/edge.cpp
@@ -9,11 +9,9 @@
 #include <catch2/catch_test_macros.hpp>
 #endif
 
-#include <algorithm>
 #include <array>
 #include <deque>
 #include <list>
-#include <numeric>
 #include <ranges>
 #include <string>
 #include <tuple>
@@ -114,7 +112,7 @@ SCENARIO("Testing gst::ranges::zip_view with edge scenarios", "[edge]")
       int   a;
       char  b;
       float c;
-      bool  operator==(Custom const& other) const
+      auto  operator==(Custom const& other) const -> bool
       {
         return std::equal_to{}(std::tie(a, b, c), std::tie(other.a, other.b, other.c));
       }

--- a/tests/iter.cpp
+++ b/tests/iter.cpp
@@ -10,13 +10,11 @@
 #endif
 #include <catch2/catch_approx.hpp>
 
-#include <algorithm>
 #include <array>
 #include <deque>
 #include <forward_list>
 #include <iterator>
 #include <list>
-#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -244,6 +242,39 @@ SCENARIO("zip_view iterator default constructor", "[iterator]")
       typename decltype(zipped)::iterator it1;
       typename decltype(zipped)::iterator it2;
       REQUIRE(it1 == it2);
+    }
+  }
+}
+
+SCENARIO("zip_view iterator inequality comparison", "[iterator]")
+{
+  GIVEN("A zip_view over three vectors")
+  {
+    std::vector<int>  vec1 = {1, 2, 3, 4, 5};
+    std::vector<char> vec2 = {'a', 'b', 'c', 'd', 'e'};
+    std::vector<int>  vec3 = {10, 20, 30, 40, 50};
+
+    auto zipped = gst::ranges::views::zip(vec1, vec2, vec3);
+
+    THEN("iterators at different positions compare unequal")
+    {
+      auto it1 = zipped.begin();
+      auto it2 = zipped.begin();
+      ++it2;
+
+      REQUIRE(it1 != it2);
+      REQUIRE_FALSE(it1 == it2);
+    }
+
+    THEN("iterators at far apart positions compare unequal")
+    {
+      auto it1 = zipped.begin();
+      auto it2 = zipped.begin();
+      ++it2;
+      ++it2;
+      ++it2;
+
+      REQUIRE(it1 != it2);
     }
   }
 }

--- a/tests/temp.cpp
+++ b/tests/temp.cpp
@@ -34,10 +34,12 @@ SCENARIO("zip_view with non-empty temporaries", "[temporaries]")
 {
   GIVEN("zip_view from temporaries")
   {
-    auto const gst_zip =
-      gst::ranges::views::zip(std::array<int, 3>{1, 2, 3}, std::list<char>{'a', 'b', 'c'});
-    auto const std_zip =
-      std::ranges::views::zip(std::array<int, 3>{1, 2, 3}, std::list<char>{'a', 'b', 'c'});
+    auto const gst_zip = gst::ranges::views::zip(std::array<int, 3>{1, 2, 3},
+                                                 std::list<char>{'a', 'b', 'c'},
+                                                 std::vector<float>{1.1F, 2.2F, 3.3F});
+    auto const std_zip = std::ranges::views::zip(std::array<int, 3>{1, 2, 3},
+                                                 std::list<char>{'a', 'b', 'c'},
+                                                 std::vector<float>{1.1F, 2.2F, 3.3F});
 
     THEN("emptiness matches std::ranges::zip_view") { REQUIRE(gst_zip.empty() == std_zip.empty()); }
     THEN("size matches std::ranges::zip_view") { REQUIRE(gst_zip.size() == std_zip.size()); }
@@ -45,11 +47,7 @@ SCENARIO("zip_view with non-empty temporaries", "[temporaries]")
     {
       auto gst_it = gst_zip.begin();
       auto std_it = std_zip.begin();
-      for (; gst_it != gst_zip.end(); ++gst_it, ++std_it)
-      {
-        REQUIRE(std::get<0>(*gst_it) == std::get<0>(*std_it));
-        REQUIRE(std::get<1>(*gst_it) == std::get<1>(*std_it));
-      }
+      for (; gst_it != gst_zip.end(); ++gst_it, ++std_it) { REQUIRE((*gst_it == *std_it)); }
       REQUIRE(std_it == std_zip.end());
     }
   }
@@ -108,20 +106,18 @@ SCENARIO("const zip_view from temporaries matches std", "[temporaries]")
 {
   GIVEN("const zip_view from temporaries")
   {
-    auto const gst_zip =
-      gst::ranges::views::zip(std::array<int, 3>{1, 2, 3}, std::vector<char>{'a', 'b', 'c'});
-    auto const std_zip =
-      std::ranges::views::zip(std::array<int, 3>{1, 2, 3}, std::vector<char>{'a', 'b', 'c'});
+    auto const gst_zip = gst::ranges::views::zip(std::array<int, 3>{1, 2, 3},
+                                                 std::vector<char>{'a', 'b', 'c'},
+                                                 std::list<double>{1.1, 2.2, 3.3});
+    auto const std_zip = std::ranges::views::zip(std::array<int, 3>{1, 2, 3},
+                                                 std::vector<char>{'a', 'b', 'c'},
+                                                 std::list<double>{1.1, 2.2, 3.3});
 
     THEN("elements match std::ranges::zip_view")
     {
       auto gst_it = gst_zip.begin();
       auto std_it = std_zip.begin();
-      for (; gst_it != gst_zip.end(); ++gst_it, ++std_it)
-      {
-        REQUIRE(std::get<0>(*gst_it) == std::get<0>(*std_it));
-        REQUIRE(std::get<1>(*gst_it) == std::get<1>(*std_it));
-      }
+      for (; gst_it != gst_zip.end(); ++gst_it, ++std_it) { REQUIRE((*gst_it == *std_it)); }
       REQUIRE(std_it == std_zip.end());
     }
   }
@@ -201,5 +197,279 @@ SCENARIO("zip_view inline usage with STL algorithms", "[temporaries]")
         dot_acc);
       REQUIRE(dot == (1 * 'a' + 2 * 'b' + 3 * 'c'));
     }
+  }
+}
+
+SCENARIO("Zipping temporary zip_views directly", "[zip_view][nested][temp]")
+{
+  std::vector<int> v1 = {1, 2, 3};
+  std::vector<int> v2 = {4, 5, 6};
+  std::vector<int> v3 = {7, 8, 9};
+  std::vector<int> v4 = {10, 11, 12};
+
+  auto nested =
+    gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), gst::ranges::views::zip(v3, v4));
+
+  THEN("Nested temporary zip_view has correct size") { REQUIRE(nested.size() == 3); }
+
+  THEN("Can dereference and access elements")
+  {
+    auto it   = nested.begin();
+    auto elem = *it;
+    auto t0   = std::get<0>(elem);
+    auto t1   = std::get<1>(elem);
+    REQUIRE(std::get<0>(t0) == 1);
+    REQUIRE(std::get<1>(t0) == 4);
+    REQUIRE(std::get<0>(t1) == 7);
+    REQUIRE(std::get<1>(t1) == 10);
+  }
+
+  THEN("Can iterate through all elements")
+  {
+    int count = 0;
+    for (auto it = nested.begin(); it != nested.end(); ++it) { ++count; }
+    REQUIRE(count == 3);
+  }
+}
+
+SCENARIO("Zipping mix of temporary and stored zip_views", "[zip_view][nested][temp]")
+{
+  std::vector<int>  v1 = {1, 2, 3};
+  std::vector<int>  v2 = {4, 5, 6};
+  std::vector<char> v3 = {'a', 'b', 'c'};
+  std::vector<char> v4 = {'x', 'y', 'z'};
+
+  auto zip1  = gst::ranges::views::zip(v1, v2);
+  auto mixed = gst::ranges::views::zip(zip1, gst::ranges::views::zip(v3, v4));
+
+  THEN("Mixed temporary structure has correct size") { REQUIRE(mixed.size() == 3); }
+
+  THEN("Can access elements from both stored and temporary zip_views")
+  {
+    auto it     = mixed.begin();
+    auto elem   = *it;
+    auto tuple0 = std::get<0>(elem);
+    auto tuple1 = std::get<1>(elem);
+    REQUIRE(std::get<0>(tuple0) == 1);
+    REQUIRE(std::get<1>(tuple0) == 4);
+    REQUIRE(std::get<0>(tuple1) == 'a');
+    REQUIRE(std::get<1>(tuple1) == 'x');
+  }
+}
+
+SCENARIO("Creating deeply nested temporary zip_views", "[zip_view][nested][temp]")
+{
+  std::vector<int> v1 = {1, 2};
+  std::vector<int> v2 = {3, 4};
+  std::vector<int> v3 = {5, 6};
+  std::vector<int> v4 = {7, 8};
+  std::vector<int> v5 = {9, 10};
+
+  auto deep = gst::ranges::views::zip(
+    gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), gst::ranges::views::zip(v3, v4)), v5);
+
+  THEN("Deep nesting with temporaries has correct size") { REQUIRE(deep.size() == 2); }
+
+  THEN("Can iterate through deeply nested temporaries")
+  {
+    int count = 0;
+    for (auto it = deep.begin(); it != deep.end(); ++it) { ++count; }
+    REQUIRE(count == 2);
+  }
+
+  THEN("Can access deeply nested elements")
+  {
+    auto it      = deep.begin();
+    auto elem    = *it;
+    auto nested1 = std::get<0>(elem);
+    auto nested2 = std::get<0>(nested1);
+    auto nested3 = std::get<1>(nested1);
+    auto regular = std::get<1>(elem);
+
+    REQUIRE(std::get<0>(nested2) == 1);
+    REQUIRE(std::get<1>(nested2) == 3);
+    REQUIRE(std::get<0>(nested3) == 5);
+    REQUIRE(std::get<1>(nested3) == 7);
+    REQUIRE(regular == 9);
+  }
+}
+
+SCENARIO("Zipping temporary containers through temporary zip_views", "[zip_view][nested][temp]")
+{
+  auto nested = gst::ranges::views::zip(
+    gst::ranges::views::zip(std::vector<int>{1, 2, 3}, std::vector<int>{4, 5, 6}),
+    gst::ranges::views::zip(std::vector<char>{'a', 'b', 'c'}, std::vector<char>{'x', 'y', 'z'}));
+
+  THEN("Temporary containers in temporary zip_views work") { REQUIRE(nested.size() == 3); }
+
+  THEN("Can iterate with temporary containers")
+  {
+    int count = 0;
+    for (auto it = nested.begin(); it != nested.end(); ++it) { ++count; }
+    REQUIRE(count == 3);
+  }
+
+  THEN("Can dereference and access temporary container elements")
+  {
+    auto it   = nested.begin();
+    auto elem = *it;
+    auto t0   = std::get<0>(elem);
+    auto t1   = std::get<1>(elem);
+    REQUIRE(std::get<0>(t0) == 1);
+    REQUIRE(std::get<1>(t0) == 4);
+    REQUIRE(std::get<0>(t1) == 'a');
+    REQUIRE(std::get<1>(t1) == 'x');
+  }
+}
+
+SCENARIO("Subscript and front/back with temporary nested zip_views", "[zip_view][nested][temp]")
+{
+  std::vector<int> v1 = {10, 20, 30};
+  std::vector<int> v2 = {40, 50, 60};
+  std::vector<int> v3 = {70, 80, 90};
+
+  auto nested =
+    gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), gst::ranges::views::zip(v2, v3));
+
+  THEN("Subscript operator works with temporary nested zip_views")
+  {
+    auto elem = nested[1];
+    auto t0   = std::get<0>(elem);
+    auto t1   = std::get<1>(elem);
+    REQUIRE(std::get<0>(t0) == 20);
+    REQUIRE(std::get<1>(t0) == 50);
+    REQUIRE(std::get<0>(t1) == 50);
+    REQUIRE(std::get<1>(t1) == 80);
+  }
+
+  THEN("front() and back() work with temporaries")
+  {
+    auto front = nested.front();
+    auto back  = nested.back();
+
+    auto front_t0 = std::get<0>(front);
+    REQUIRE(std::get<0>(front_t0) == 10);
+
+    auto back_t1 = std::get<1>(back);
+    REQUIRE(std::get<1>(back_t1) == 90);
+  }
+}
+
+SCENARIO("Modifying through temporary nested zip_views", "[zip_view][nested][temp]")
+{
+  std::vector<int> v1 = {1, 2, 3};
+  std::vector<int> v2 = {4, 5, 6};
+  std::vector<int> v3 = {7, 8, 9};
+
+  auto nested = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+
+  THEN("Can modify underlying containers through temporary zip_view")
+  {
+    auto it           = nested.begin();
+    auto elem         = *it;
+    std::get<1>(elem) = 99;
+    REQUIRE(v3[0] == 99);
+
+    auto nested_tuple         = std::get<0>(elem);
+    std::get<0>(nested_tuple) = 88;
+    REQUIRE(v1[0] == 88);
+  }
+}
+
+SCENARIO("Comparing temporary nested zip_views with std::ranges::zip_view",
+         "[zip_view][nested][temp]")
+{
+  std::vector<int> v1 = {1, 2, 3};
+  std::vector<int> v2 = {4, 5, 6};
+  std::vector<int> v3 = {7, 8, 9};
+  std::vector<int> v4 = {10, 11, 12};
+
+  auto gst_nested = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2, v3),
+                                            gst::ranges::views::zip(v2, v3, v4),
+                                            gst::ranges::views::zip(v3, v4, v1));
+  auto std_nested = std::ranges::views::zip(std::ranges::views::zip(v1, v2, v3),
+                                            std::ranges::views::zip(v2, v3, v4),
+                                            std::ranges::views::zip(v3, v4, v1));
+
+  THEN("Temporary nested structures match std behavior")
+  {
+    REQUIRE(gst_nested.size() == std_nested.size());
+    REQUIRE(gst_nested.empty() == std_nested.empty());
+    REQUIRE(std::ranges::equal(gst_nested, std_nested));
+  }
+}
+
+SCENARIO("Range-based for on inline temporary nested zip_views", "[zip_view][nested][temp]")
+{
+  std::vector<int> v1 = {1, 2, 3};
+  std::vector<int> v2 = {4, 5, 6};
+  std::vector<int> v3 = {7, 8, 9};
+
+  THEN("Can iterate with range-based for on temporary nested zip_views")
+  {
+    auto nested =
+      gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), gst::ranges::views::zip(v2, v3));
+    int count = 0;
+    for (auto elem : nested)
+    {
+      (void)elem;
+      ++count;
+    }
+    REQUIRE(count == 3);
+  }
+
+  THEN("Can modify through range-based for on temporary nested zip_views")
+  {
+    auto nested = gst::ranges::views::zip(gst::ranges::views::zip(v1, v2), v3);
+
+    for (auto&& elem : nested)
+    {
+      auto nested_tuple          = std::get<0>(elem);
+      std::get<0>(nested_tuple) *= 2;
+      std::get<1>(elem)         += 100;
+    }
+
+    REQUIRE(v1 == std::vector<int>{2, 4, 6});
+    REQUIRE(v3 == std::vector<int>{107, 108, 109});
+  }
+}
+
+SCENARIO("Range-based for on stored nested zip_views", "[zip_view][nested][temp]")
+{
+  std::vector<int> v1 = {10, 20, 30};
+  std::vector<int> v2 = {40, 50, 60};
+  std::vector<int> v3 = {70, 80, 90};
+  std::vector<int> v4 = {100, 110, 120};
+
+  auto zip1   = gst::ranges::views::zip(v1, v2);
+  auto zip2   = gst::ranges::views::zip(v3, v4);
+  auto nested = gst::ranges::views::zip(zip1, zip2);
+
+  THEN("Can iterate with range-based for on stored nested zip_views")
+  {
+    int count = 0;
+    int sum   = 0;
+    for (auto elem : nested)
+    {
+      auto t0  = std::get<0>(elem);
+      sum     += std::get<0>(t0);
+      ++count;
+    }
+    REQUIRE(count == 3);
+    REQUIRE(sum == 60); // 10 + 20 + 30
+  }
+
+  THEN("Can modify through range-based for on stored nested zip_views")
+  {
+    for (auto&& elem : nested)
+    {
+      auto t0          = std::get<0>(elem);
+      auto t1          = std::get<1>(elem);
+      std::get<0>(t0) += 5;
+      std::get<1>(t1) += 10;
+    }
+
+    REQUIRE(v1 == std::vector<int>{15, 25, 35});
+    REQUIRE(v4 == std::vector<int>{110, 120, 130});
   }
 }

--- a/tests/temp.cpp
+++ b/tests/temp.cpp
@@ -22,11 +22,14 @@ SCENARIO("zip_view with empty temporaries", "[temporaries]")
 {
   GIVEN("zip_view from empty temporaries")
   {
-    auto const gst_zip = gst::ranges::views::zip(std::array<int, 0>{}, std::list<char>{});
-    auto const std_zip = std::ranges::views::zip(std::array<int, 0>{}, std::list<char>{});
+    auto gst_zip =
+      gst::ranges::views::zip(std::array<int, 0>{}, std::list<char>{}, std::vector<float>{});
+    auto std_zip =
+      std::ranges::views::zip(std::array<int, 0>{}, std::list<char>{}, std::vector<float>{});
 
     THEN("zip_view is empty") { REQUIRE(gst_zip.empty() == std_zip.empty()); }
     THEN("size is zero") { REQUIRE(gst_zip.size() == std_zip.size()); }
+    THEN("zip_views are equal") { REQUIRE(std::ranges::equal(gst_zip, std_zip)); }
   }
 }
 
@@ -34,22 +37,16 @@ SCENARIO("zip_view with non-empty temporaries", "[temporaries]")
 {
   GIVEN("zip_view from temporaries")
   {
-    auto const gst_zip = gst::ranges::views::zip(std::array<int, 3>{1, 2, 3},
-                                                 std::list<char>{'a', 'b', 'c'},
-                                                 std::vector<float>{1.1F, 2.2F, 3.3F});
-    auto const std_zip = std::ranges::views::zip(std::array<int, 3>{1, 2, 3},
-                                                 std::list<char>{'a', 'b', 'c'},
-                                                 std::vector<float>{1.1F, 2.2F, 3.3F});
+    auto gst_zip = gst::ranges::views::zip(std::array<int, 3>{1, 2, 3},
+                                           std::list<char>{'a', 'b', 'c'},
+                                           std::vector<float>{1.1F, 2.2F, 3.3F});
+    auto std_zip = std::ranges::views::zip(std::array<int, 3>{1, 2, 3},
+                                           std::list<char>{'a', 'b', 'c'},
+                                           std::vector<float>{1.1F, 2.2F, 3.3F});
 
     THEN("emptiness matches std::ranges::zip_view") { REQUIRE(gst_zip.empty() == std_zip.empty()); }
     THEN("size matches std::ranges::zip_view") { REQUIRE(gst_zip.size() == std_zip.size()); }
-    THEN("elements match std::ranges::zip_view")
-    {
-      auto gst_it = gst_zip.begin();
-      auto std_it = std_zip.begin();
-      for (; gst_it != gst_zip.end(); ++gst_it, ++std_it) { REQUIRE((*gst_it == *std_it)); }
-      REQUIRE(std_it == std_zip.end());
-    }
+    THEN("elements match std::ranges::zip_view") { REQUIRE(std::ranges::equal(gst_zip, std_zip)); }
   }
 }
 
@@ -57,8 +54,12 @@ SCENARIO("zip_view owns temporaries data", "[temporaries]")
 {
   GIVEN("zip_view from rvalue containers")
   {
-    auto gst_zip =
-      gst::ranges::views::zip(std::vector<int>{1, 2, 3}, std::vector<char>{'a', 'b', 'c'});
+    auto gst_zip = gst::ranges::views::zip(std::vector<int>{1, 2, 3},
+                                           std::vector<char>{'a', 'b', 'c'},
+                                           std::vector<float>{1.1F, 2.2F, 3.3F});
+    auto std_zip = std::ranges::views::zip(std::vector<int>{11, 12, 13},
+                                           std::vector<char>{'A', 'B', 'C'},
+                                           std::vector<float>{11.1F, 12.2F, 13.3F});
 
     WHEN("mutating values through the view")
     {
@@ -66,14 +67,10 @@ SCENARIO("zip_view owns temporaries data", "[temporaries]")
       {
         std::get<0>(t) += 10;
         std::get<1>(t)  = static_cast<char>(std::get<1>(t) - 'a' + 'A');
+        std::get<2>(t) += 10.0F;
       }
 
-      THEN("mutations are observable")
-      {
-        REQUIRE((gst_zip[0] == std::make_tuple(11, 'A')));
-        REQUIRE((gst_zip[1] == std::make_tuple(12, 'B')));
-        REQUIRE((gst_zip[2] == std::make_tuple(13, 'C')));
-      }
+      THEN("mutations are observable") { REQUIRE(std::ranges::equal(gst_zip, std_zip)); }
     }
   }
 }
@@ -113,13 +110,7 @@ SCENARIO("const zip_view from temporaries matches std", "[temporaries]")
                                                  std::vector<char>{'a', 'b', 'c'},
                                                  std::list<double>{1.1, 2.2, 3.3});
 
-    THEN("elements match std::ranges::zip_view")
-    {
-      auto gst_it = gst_zip.begin();
-      auto std_it = std_zip.begin();
-      for (; gst_it != gst_zip.end(); ++gst_it, ++std_it) { REQUIRE((*gst_it == *std_it)); }
-      REQUIRE(std_it == std_zip.end());
-    }
+    THEN("elements match std::ranges::zip_view") { REQUIRE(std::ranges::equal(gst_zip, std_zip)); }
   }
 }
 


### PR DESCRIPTION
Replace std::tie with direct tuple construction in subscripts() and
dereference() methods. std::tie requires lvalue references but nested
zip_views return tuple values, causing compilation errors.

Add tests covering:
- Basic nested zip_view operations (empty, single, multiple, mixed)
- Temporary nested zip_views with inline creation
- Range-based for loops with nested structures
- STL algorithms (for_each, transform, find_if, accumulate, etc.)